### PR TITLE
build: fix compilation with gcc 13

### DIFF
--- a/src/emucore/TIASnd.hxx
+++ b/src/emucore/TIASnd.hxx
@@ -18,6 +18,7 @@
 
 #ifndef TIASOUND_HXX
 #define TIASOUND_HXX
+#include <cstdint>
 
 namespace ale {
 namespace stella {


### PR DESCRIPTION
This include is necessary for the project to compile with GCC 13.
See https://gcc.gnu.org/gcc-13/porting_to.html

Fixes #502 