### PR TITLE
Bump `actions/download-artifact` and `actions/upload-artifact` v4

### DIFF
--- a/.github/docker/manylinux-vcpkg.Dockerfile
+++ b/.github/docker/manylinux-vcpkg.Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/pypa/manylinux2014_x86_64
 
-LABEL org.opencontainers.image.source https://github.com/Farama-Foundation/Arcade-Learning-Environment
+LABEL org.opencontainers.image.source=https://github.com/Farama-Foundation/Arcade-Learning-Environment
 
 RUN yum install -y curl unzip zip tar
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,8 @@ jobs:
         with:
           name: wheels-${{ runner.os }}-${{ matrix.arch }}
 
+      - run: ls /
+
       - run: ls wheels-${{ runner.os }}-${{ matrix.arch }}/
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,8 +194,8 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
-          path: ./wheelhouse-${{ matrix.runner-on }}-$${{ matrix.arch }}/*.whl
+          name: wheels-${{ matrix.runs-on }}-${{ matrix.arch }}
+          path: ./wheelhouse/*.whl
 
   test-wheels:
     name: Test wheels
@@ -209,69 +209,89 @@ jobs:
           # ale_py-0.x.x-cp310-cp310-macosx_11_0_arm64.whl
           # ale_py-0.x.x-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
           # ale_py-0.x.x-cp310-cp310-win_amd64.whl
-          - runs-on: ubuntu-latest  # arch: x86_64
+          - runs-on: ubuntu-latest
             python: '3.8'
             wheel-name: 'cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64'
-          - runs-on: ubuntu-latest  # arch: x86_64
+            arch: 'x86_x64'
+          - runs-on: ubuntu-latest
             python: '3.9'
             wheel-name: 'cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64'
-          - runs-on: ubuntu-latest  # arch: x86_64
+            arch: 'x86_x64'
+          - runs-on: ubuntu-latest
             python: '3.10'
             wheel-name: 'cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64'
-          - runs-on: ubuntu-latest  # arch: x86_64
+            arch: 'x86_x64'
+          - runs-on: ubuntu-latest
             python: '3.11'
             wheel-name: 'cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64'
-          - runs-on: ubuntu-latest  # arch: x86_64
+            arch: 'x86_x64'
+          - runs-on: ubuntu-latest
             python: '3.12'
             wheel-name: 'cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64'
+            arch: 'x86_x64'
 
-          - runs-on: windows-latest  # arch: AMD64
+          - runs-on: windows-latest
             python: '3.8'
             wheel-name: 'cp38-cp38-win_amd64'
-          - runs-on: windows-latest  # arch: AMD64
+            arch: AMD64
+          - runs-on: windows-latest
             python: '3.9'
             wheel-name: 'cp39-cp39-win_amd64'
-          - runs-on: windows-latest  # arch: AMD64
+            arch: AMD64
+          - runs-on: windows-latest
             python: '3.10'
             wheel-name: 'cp310-cp310-win_amd64'
-          - runs-on: windows-latest  # arch: AMD64
+            arch: AMD64
+          - runs-on: windows-latest
             python: '3.11'
             wheel-name: 'cp311-cp311-win_amd64'
-          - runs-on: windows-latest  # arch: AMD64
+            arch: AMD64
+          - runs-on: windows-latest
             python: '3.12'
             wheel-name: 'cp312-cp312-win_amd64'
+            arch: AMD64
 
-          - runs-on: macos-12  # arch: x86_64
+          - runs-on: macos-12
             python: '3.8'
             wheel-name: 'cp38-cp38-macosx_10_15_x86_64'
-          - runs-on: macos-12  # arch: x86_64
+            arch: x86_64
+          - runs-on: macos-12
             python: '3.9'
             wheel-name: 'cp39-cp39-macosx_10_15_x86_64'
-          - runs-on: macos-12  # arch: x86_64
+            arch: x86_64
+          - runs-on: macos-12
             python: '3.10'
             wheel-name: 'cp310-cp310-macosx_10_15_x86_64'
-          - runs-on: macos-12  # arch: x86_64
+            arch: x86_64
+          - runs-on: macos-12
             python: '3.11'
             wheel-name: 'cp311-cp311-macosx_10_15_x86_64'
-          - runs-on: macos-12  # arch: x86_64
+            arch: x86_64
+          - runs-on: macos-12
             python: '3.12'
             wheel-name: 'cp312-cp312-macosx_10_15_x86_64'
+            arch: x86_64
 
-          - runs-on: macos-14  # arch: arm64
+          - runs-on: macos-14
             python: '3.8'
             wheel-name: 'cp38-cp38-macosx_11_0_arm64'
-          - runs-on: macos-14  # arch: arm64
+            arch: arm64
+          - runs-on: macos-14
             python: '3.9'
             wheel-name: 'cp39-cp39-macosx_11_0_arm64'
-          - runs-on: macos-14  # arch: arm64
+            arch: arm64
+          - runs-on: macos-14
             python: '3.10'
             wheel-name: 'cp310-cp310-macosx_11_0_arm64'
-          - runs-on: macos-14  # arch: arm64
+            arch: arm64
+          - runs-on: macos-14
             python: '3.11'
             wheel-name: 'cp311-cp311-macosx_11_0_arm64'
-          - runs-on: macos-14  # arch: arm64
+            arch: arm64
+          - runs-on: macos-14
             python: '3.12'
             wheel-name: 'cp312-cp312-macosx_11_0_arm64'
+            arch: arm64
 
     runs-on: ${{ matrix.runs-on }}
 
@@ -283,13 +303,13 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.runs-on }}-${{ matrix.arch }}
 
-      - run: ls wheels/
+      - run: ls wheels-${{ matrix.runs-on }}-${{ matrix.arch }}/
 
       - name: Build
         # wildcarding doesn't work for some reason, therefore, update the project version here
-        run: python -m pip install wheels/ale_py-0.9.1-${{ matrix.wheel-name }}.whl
+        run: python -m pip install wheels-${{ matrix.runs-on }}-${{ matrix.arch }}/ale_py-0.9.1-${{ matrix.wheel-name }}.whl
 
       - name: Install Gymnasium and pytest
         run: python -m pip install gymnasium>=1.0.0a2 pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
             arch: AMD64
           - runs-on: macos-12
             arch: x86_64
-          - runs-on: macos-14
+          - runs-on: macos-12
             arch: arm64
     runs-on: ${{ matrix.runs-on }}
 
@@ -194,7 +194,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.runs-on }}-${{ matrix.arch }}
+          name: wheels-${{ runner.os }}-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
 
   test-wheels:
@@ -303,13 +303,13 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: wheels-${{ matrix.runs-on }}-${{ matrix.arch }}
+          name: wheels-${{ runner.os }}-${{ matrix.arch }}
 
-      - run: ls wheels-${{ matrix.runs-on }}-${{ matrix.arch }}/
+      - run: ls wheels-${{ runner.os }}-${{ matrix.arch }}/
 
       - name: Build
         # wildcarding doesn't work for some reason, therefore, update the project version here
-        run: python -m pip install wheels-${{ matrix.runs-on }}-${{ matrix.arch }}/ale_py-0.9.1-${{ matrix.wheel-name }}.whl
+        run: python -m pip install wheels-${{ runner.os }}-${{ matrix.arch }}/ale_py-0.9.1-${{ matrix.wheel-name }}.whl
 
       - name: Install Gymnasium and pytest
         run: python -m pip install gymnasium>=1.0.0a2 pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,7 @@ jobs:
         with:
           name: wheels-${{ runner.os }}-${{ matrix.arch }}
 
-      - run: ls /
+      - run: ls
 
       - run: ls wheels-${{ runner.os }}-${{ matrix.arch }}/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheels
-          path: ./wheelhouse/*.whl
+          path: ./wheelhouse-${{ matrix.runner-on }}-$${{ matrix.arch }}/*.whl
 
   test-wheels:
     name: Test wheels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
             arch: AMD64
           - runs-on: macos-12
             arch: x86_64
-          - runs-on: macos-12
+          - runs-on: macos-14
             arch: arm64
     runs-on: ${{ matrix.runs-on }}
 
@@ -212,23 +212,23 @@ jobs:
           - runs-on: ubuntu-latest
             python: '3.8'
             wheel-name: 'cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64'
-            arch: 'x86_x64'
+            arch: 'x86_64'
           - runs-on: ubuntu-latest
             python: '3.9'
             wheel-name: 'cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64'
-            arch: 'x86_x64'
+            arch: 'x86_64'
           - runs-on: ubuntu-latest
             python: '3.10'
             wheel-name: 'cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64'
-            arch: 'x86_x64'
+            arch: 'x86_64'
           - runs-on: ubuntu-latest
             python: '3.11'
             wheel-name: 'cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64'
-            arch: 'x86_x64'
+            arch: 'x86_64'
           - runs-on: ubuntu-latest
             python: '3.12'
             wheel-name: 'cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64'
-            arch: 'x86_x64'
+            arch: 'x86_64'
 
           - runs-on: windows-latest
             python: '3.8'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
           CIBW_ARCHS: "${{ matrix.arch }}"
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: ./wheelhouse/*.whl
@@ -281,7 +281,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: wheels
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,11 +307,9 @@ jobs:
 
       - run: ls
 
-      - run: ls wheels-${{ runner.os }}-${{ matrix.arch }}/
-
       - name: Build
         # wildcarding doesn't work for some reason, therefore, update the project version here
-        run: python -m pip install wheels-${{ runner.os }}-${{ matrix.arch }}/ale_py-0.9.1-${{ matrix.wheel-name }}.whl
+        run: python -m pip install ale_py-0.9.1-${{ matrix.wheel-name }}.whl
 
       - name: Install Gymnasium and pytest
         run: python -m pip install gymnasium>=1.0.0a2 pytest

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-${{ matrix.runs-on }}-${{ matrix.arch }}
         path: ./wheelhouse/*.whl
 
   push-pypi:
@@ -88,7 +88,11 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          name: | 
+            wheels-windows-latest-x86_64/
+            wheels-ubuntu-latest-ARM64/
+            wheels-macos-12-x86_64/
+            wheels-macos-12-arm64/
 
       - name: Publish to PyPi test
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -93,6 +93,7 @@ jobs:
             wheels-ubuntu-latest-ARM64/
             wheels-macos-12-x86_64/
             wheels-macos-12-arm64/
+          path: wheels
 
       - name: Publish to PyPi test
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -73,7 +73,7 @@ jobs:
         CIBW_ARCHS: "${{ matrix.arch }}"
 
     - name: Upload wheels
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: wheels
         path: ./wheelhouse/*.whl
@@ -86,7 +86,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: wheels
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: | 
+          name: |
             wheels-windows-latest-x86_64/
             wheels-ubuntu-latest-ARM64/
             wheels-macos-12-x86_64/


### PR DESCRIPTION
Dependabot couldn't update `actions/download-artifact` and `actions/upload-artifact` v4 at the same time as they need to be updated at the same time according to the release notes