### PR TITLE
Add pydocstyle to pre-commit, fix `get_keys_to_action` and environment frameskip

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-symlinks
       - id: destroyed-symlinks
@@ -25,7 +25,7 @@ repos:
 #        args:
 #          - --ignore-words-list=
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+    rev: 7.1.1
     hooks:
       - id: flake8
         args:
@@ -36,7 +36,7 @@ repos:
           - --show-source
           - --statistics
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.17.0
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]
@@ -46,16 +46,16 @@ repos:
       - id: isort
         args: ["--profile", "black"]
   - repo: https://github.com/python/black
-    rev: 23.12.1
+    rev: 24.8.0
     hooks:
       - id: black
-#  - repo: https://github.com/pycqa/pydocstyle
-#    rev: 6.3.0
-#    hooks:
-#      - id: pydocstyle
-##        exclude: ^
-#        args:
-#          - --source
-#          - --explain
-#          - --convention=google
-#        additional_dependencies: ["tomli"]
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: 6.3.0
+    hooks:
+      - id: pydocstyle
+        exclude: ^(docs/)|setup.py
+        args:
+          - --source
+          - --explain
+          - --convention=google
+        additional_dependencies: ["tomli"]

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -197,7 +197,7 @@ The differences are listed in the following table:
 |---------|--------------|------------------------------|----------------------|
 | v0      | `(2, 5,)`    | `0.25`                       | `False`              |
 | v4      | `(2, 5,)`    | `0.0`                        | `False`              |
-| v5      | `5`          | `0.25`                       | `False`              |
+| v5      | `4`          | `0.25`                       | `False`              |
 
 > Version v5 follows the best practices outlined in [[2]](#2). Thus, it is recommended to transition to v5 and
 customize the environment using the arguments above, if necessary.
@@ -220,8 +220,8 @@ are in the "ALE" namespace. The suffix "-ram" is still available. Thus, we get t
 
 | Name              | `obs_type=` | `frameskip=` | `repeat_action_probability=` |
 |-------------------|-------------|--------------|------------------------------|
-| ALE/Amidar-v5     | `"rgb"`     | `5`          | `0.25`                       |
-| ALE/Amidar-ram-v5 | `"ram"`     | `5`          | `0.25`                       |
+| ALE/Amidar-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Amidar-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
 
 ## Flavors
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+"""Setup file for ALE."""
+
 import os
 import re
 import subprocess
@@ -6,7 +8,7 @@ import sys
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-here = os.path.abspath(os.path.dirname(__file__))
+current_working_file = os.path.abspath(os.path.dirname(__file__))
 
 
 class CMakeExtension(Extension):
@@ -108,8 +110,7 @@ class CMakeBuild(build_ext):
 
 
 def parse_version(version_file):
-    """
-    Parse version from `version_file`.
+    """Parse version from `version_file`.
 
     If we're running on CI, i.e., CIBUILDWHEEL is set, then we'll parse
     the version from `GITHUB_REF` using the official semver regex.
@@ -132,7 +133,7 @@ def parse_version(version_file):
 
 if __name__ == "__main__":
     # Allow for running `pip wheel` from other directories
-    here and os.chdir(here)
+    current_working_file and os.chdir(current_working_file)
     # Most config options are in `setup.cfg`. These are the
     # only dynamic options we need at build time.
     setup(

--- a/src/ale/python/__init__.py
+++ b/src/ale/python/__init__.py
@@ -1,3 +1,5 @@
+"""Python module for interacting with ALE c++ interface and gymnasium wrapper."""
+
 import os
 import platform
 import sys

--- a/src/ale/python/__init__.pyi
+++ b/src/ale/python/__init__.pyi
@@ -28,6 +28,7 @@ class LoggerMode:
         """
         :type: str
         """
+
     @property
     def value(self) -> int:
         """
@@ -54,6 +55,7 @@ class Action:
         """
         :type: str
         """
+
     @property
     def value(self) -> int:
         """

--- a/src/ale/python/registration.py
+++ b/src/ale/python/registration.py
@@ -1,3 +1,5 @@
+"""Registration for Atari environments."""
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -8,25 +10,24 @@ import gymnasium
 
 
 class EnvFlavour(NamedTuple):
+    """Environment flavour for env id suffix and kwargs."""
+
     suffix: str
     kwargs: Mapping[str, Any] | Callable[[str], Mapping[str, Any]]
 
 
 class EnvConfig(NamedTuple):
+    """Environment config for version, kwargs and flavours."""
+
     version: str
     kwargs: Mapping[str, Any]
     flavours: Sequence[EnvFlavour]
 
 
 def _rom_id_to_name(rom: str) -> str:
-    """
-    Let the ROM ID be the ROM identifier in snake_case.
-        For example, `space_invaders`
-    The ROM name is the ROM ID in pascalcase.
-        For example, `SpaceInvaders`
+    """Converts the Rom ID (snake_case) to ROM name in PascalCase.
 
-    This function converts the ROM ID to the ROM name.
-        i.e., snakecase -> pascalcase
+    For example, `space_invaders` to `SpaceInvaders`
     """
     return rom.title().replace("_", "")
 
@@ -72,6 +73,7 @@ def _register_rom_configs(
 
 
 def register_v0_v4_envs():
+    """Registers all v0 and v4 environments."""
     legacy_games = [
         "adventure",
         "air_raid",
@@ -177,6 +179,7 @@ def register_v0_v4_envs():
 
 
 def register_v5_envs():
+    """Register all v5 environments."""
     all_games = roms.get_all_rom_ids()
     obs_types = ["rgb", "ram"]
 

--- a/src/ale/python/roms/__init__.py
+++ b/src/ale/python/roms/__init__.py
@@ -1,3 +1,5 @@
+"""Rom module with functions for collecting individual and all ROMS files."""
+
 from __future__ import annotations
 
 import functools

--- a/tests/python/test_atari_env.py
+++ b/tests/python/test_atari_env.py
@@ -270,7 +270,7 @@ def test_gym_img_rgb_obs(tetris_env):
 @pytest.mark.parametrize("tetris_env", [{"full_action_space": True}], indirect=True)
 def test_gym_keys_to_action(tetris_env):
     keys_full_action_space = {
-        (None,): 0,
+        (101,): 0,
         (32,): 1,
         (119,): 2,
         (100,): 3,

--- a/tests/python/test_atari_env.py
+++ b/tests/python/test_atari_env.py
@@ -9,7 +9,7 @@ import pytest
 from ale_py.env import AtariEnv
 from ale_py.registration import _register_rom_configs, register_v0_v4_envs
 from gymnasium.utils.env_checker import check_env
-from utils import test_rom_path, tetris_env  # noqa: F401
+from utils import tetris_env, tetris_rom_path  # noqa: F401
 
 _ACCEPTABLE_WARNING_SNIPPETS = [
     "is out of date. You should consider upgrading to version",
@@ -165,8 +165,8 @@ def test_register_legacy_env_id():
         assert all_ids.issubset(envids)
 
 
-def test_register_gym_envs(test_rom_path):
-    with patch("ale_py.roms.Tetris", create=True, new_callable=lambda: test_rom_path):
+def test_register_gym_envs(tetris_rom_path):
+    with patch("ale_py.roms.Tetris", create=True, new_callable=lambda: tetris_rom_path):
         # Register internal IDs
         # register_v5_envs()
 
@@ -368,8 +368,8 @@ def test_gym_reset_with_infos(tetris_env):
 
 
 @pytest.mark.parametrize("frameskip", [0, -1, 4.0, (-1, 5), (0, 5), (5, 2), (1, 2, 3)])
-def test_frameskip_warnings(test_rom_path, frameskip):
-    with patch("ale_py.roms.Tetris", create=True, new_callable=lambda: test_rom_path):
+def test_frameskip_warnings(tetris_rom_path, frameskip):
+    with patch("ale_py.roms.Tetris", create=True, new_callable=lambda: tetris_rom_path):
         with pytest.raises(gymnasium.error.Error):
             AtariEnv("Tetris", frameskip=frameskip)
 

--- a/tests/python/test_python_interface.py
+++ b/tests/python/test_python_interface.py
@@ -5,7 +5,7 @@ import tempfile
 import ale_py
 import numpy as np
 import pytest
-from utils import ale, random_rom_path, test_rom_path, tetris  # noqa: F401
+from utils import ale, random_rom_path, tetris, tetris_rom_path  # noqa: F401
 
 
 def test_ale_version():
@@ -63,10 +63,10 @@ def test_game_over(tetris):
     assert tetris.game_over()
 
 
-def test_game_over_truncation(ale, test_rom_path):
+def test_game_over_truncation(ale, tetris_rom_path):
     ale.setInt("max_num_frames_per_episode", 10)
     ale.setInt("frame_skip", 1)
-    ale.loadROM(test_rom_path)
+    ale.loadROM(tetris_rom_path)
     ale.reset_game()
     for _ in range(10):
         ale.act(0)
@@ -223,8 +223,8 @@ def test_save_screen_png(tetris):
     os.remove(file)
 
 
-def test_is_rom_supported(ale, test_rom_path, random_rom_path):
-    assert ale.isSupportedROM(test_rom_path)
+def test_is_rom_supported(ale, tetris_rom_path, random_rom_path):
+    assert ale.isSupportedROM(tetris_rom_path)
     assert ale.isSupportedROM(random_rom_path) is None
     with pytest.raises(RuntimeError):
         ale.isSupportedROM("notfound")
@@ -241,10 +241,10 @@ def test_clone_restore_state(tetris):
     assert tetris.cloneState() == state
 
 
-def test_clone_restore_state_determinism(ale, test_rom_path):
+def test_clone_restore_state_determinism(ale, tetris_rom_path):
     ale.setInt("random_seed", 0)
     ale.setFloat("repeat_action_probability", 0.0)
-    ale.loadROM(test_rom_path)
+    ale.loadROM(tetris_rom_path)
     ale.reset_game()
 
     num_actions = 100
@@ -270,10 +270,10 @@ def test_clone_restore_state_determinism(ale, test_rom_path):
     assert not all_equal
 
 
-def test_clone_restore_state_stochasticity(ale, test_rom_path):
+def test_clone_restore_state_stochasticity(ale, tetris_rom_path):
     ale.setInt("random_seed", 0)
     ale.setFloat("repeat_action_probability", 0.25)
-    ale.loadROM(test_rom_path)
+    ale.loadROM(tetris_rom_path)
     ale.reset_game()
 
     num_actions = 100
@@ -299,10 +299,10 @@ def test_clone_restore_state_stochasticity(ale, test_rom_path):
     assert not all_equal
 
 
-def test_clone_restore_state_include_rng(ale, test_rom_path):
+def test_clone_restore_state_include_rng(ale, tetris_rom_path):
     ale.setInt("random_seed", 0)
     ale.setFloat("repeat_action_probability", 0.25)
-    ale.loadROM(test_rom_path)
+    ale.loadROM(tetris_rom_path)
     ale.reset_game()
 
     num_actions = 100
@@ -339,10 +339,10 @@ def test_clone_restore_state_include_rng(ale, test_rom_path):
     assert not _all_equal(second_half, second_half_without_rng)
 
 
-def test_clone_restore_system_state(ale, test_rom_path):
+def test_clone_restore_system_state(ale, tetris_rom_path):
     ale.setInt("random_seed", 0)
     ale.setFloat("repeat_action_probability", 0.25)
-    ale.loadROM(test_rom_path)
+    ale.loadROM(tetris_rom_path)
     ale.reset_game()
 
     num_actions = 100
@@ -394,11 +394,11 @@ def test_state_pickle(tetris):
 
 
 @pytest.mark.skipif(ale_py.SDL_SUPPORT is False, reason="SDL is disabled")
-def test_display_screen(ale, test_rom_path):
+def test_display_screen(ale, tetris_rom_path):
     os.environ["SDL_VIDEODRIVER"] = "dummy"
     ale.setBool("display_screen", True)
     ale.setBool("sound", False)
-    ale.loadROM(test_rom_path)
+    ale.loadROM(tetris_rom_path)
     for _ in range(10):
         ale.act(0)
     del os.environ["SDL_VIDEODRIVER"]

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -1,3 +1,5 @@
+"""Utility functions for testing."""
+
 import os
 from unittest.mock import patch
 
@@ -7,7 +9,8 @@ import pytest
 
 
 @pytest.fixture
-def test_rom_path():
+def tetris_rom_path():
+    """Gets the ROM path of `tetris`."""
     yield os.path.join(
         os.path.abspath(os.path.dirname(__file__)), "..", "resources", "tetris.bin"
     )
@@ -15,6 +18,7 @@ def test_rom_path():
 
 @pytest.fixture
 def random_rom_path():
+    """Gets the ROM path of `random`."""
     yield os.path.join(
         os.path.abspath(os.path.dirname(__file__)), "..", "resources", "random.bin"
     )
@@ -22,19 +26,22 @@ def random_rom_path():
 
 @pytest.fixture
 def ale():
+    """Gets an ALE interface."""
     yield ale_py.ALEInterface()
 
 
 @pytest.fixture
-def tetris(ale, test_rom_path):
-    ale.loadROM(test_rom_path)
+def tetris(ale, tetris_rom_path):
+    """Loads tetris."""
+    ale.loadROM(tetris_rom_path)
     yield ale
 
 
 @pytest.fixture
-def tetris_env(request, test_rom_path):
+def tetris_env(request, tetris_rom_path):
+    """Pytest fixture for creating a tetris environment."""
     with patch(
-        "ale_py.roms.tetris_test", create=True, new_callable=lambda: test_rom_path
+        "ale_py.roms.tetris_test", create=True, new_callable=lambda: tetris_rom_path
     ):
         gymnasium.register(
             id="TetrisTest-v0",


### PR DESCRIPTION
This PR fixes several issues
* Add pydocstyle to pre-commit
* `get_keys_to_action` had `None` for no-op however for `gymnasium.utils.play.play` this is not allowed, therefore, this is updated to use `e` for no-op (https://github.com/Farama-Foundation/Arcade-Learning-Environment/issues/557)
* The environment frameskip for v5 specified it was 5 however it was actually 4