### PR TITLE
Fix main page example 'Breakout' to 'breakout'

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can now import the ALE in your Python projects with providing a direct inter
 from ale_py import ALEInterface, roms
 
 ale = ALEInterface()
-ale.loadROM(roms.get_rom_path("Breakout"))
+ale.loadROM(roms.get_rom_path("breakout"))
 ale.reset_game()
 
 reward = ale.act(0)  # noop


### PR DESCRIPTION
This PR fixes a typo in the Quickstart of README.md. 

If one follows the README.md example below in Linux:

```python
from ale_py import ALEInterface, roms

ale = ALEInterface()
x = roms.get_rom_path("Breakout")
ale.loadROM(x)
ale.reset_game()

reward = ale.act(0)  # noop
screen_obs = ale.getScreenRGB()
```

you get `UserWarning: Rom Breakout not supported.` and `get_rom_path` returns `None` and then
```
TypeError: loadROM(): incompatible function arguments. The following argument types are supported:
    1. (self: ale_py._ale_py.ALEInterface, arg0: str) -> None
    2. (self: ale_py._ale_py.ALEInterface, arg0: os.PathLike) -> None
```

The issue is the file search is case sensitive. To fix, just run the same with `breakout` instead of `Breakout`.