### PR TITLE
Add CALE instructions and citation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ while not episode_over:
 env.close()
 ```
 
+To run with continuous actions, you can simply modify the call to `gym.make` above with:
+```python
+env = gym.make('ALE/Breakout-v5', continuous=True, render_mode="human")
+```
+
 For all the environments available and their description, see [gymnasium atari page](https://gymnasium.farama.org/environments/atari/).
 
 C++
@@ -137,5 +142,20 @@ In BibTex format:
     volume = {61},
     pages = {523--562},
     year = {2018}
+}
+```
+
+If you use the CALE (Continuous ALE), we ask you that you also cite the following:
+
+*Jesse Farebrother and Pablo Samuel Castro.  Cale:  Continuous arcade learning environment.Ad-vances in Neural Information Processing Systems, 2024.*
+
+In BibTex format:
+
+```bibtex
+@article{farebrother2024cale,
+  title={C{ALE}: Continuous Arcade Learning Environment},
+  author={Jesse Farebrother and Pablo Samuel Castro},
+  journal={Advances in Neural Information Processing Systems},
+  year={2024}
 }
 ```

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -133,6 +133,18 @@ Each environment will use a sub-set of the full action space listed below:
 By default, most environments use a smaller subset of the legal actions excluding any actions that don't have an effect in the game.
 If users are interested in using all possible actions, pass the keyword argument `full_action_space=True` to `gymnasium.make`.
 
+## Continuous action space
+
+The ALE supports continuous actions, parameterized as a 3-dimensional vector. The first two dimensions specify polar coordinates
+(radius, theta), while the last dimension is the "fire" dimension. The ranges are:
+1. **radius**: `[0.0, 1.0]`
+2. **theta**: `[-np.pi, np.pi]`
+3. **fire**: `[0.0, 1.0]`
+
+Continuous action spaces still trigger the same events as the default discrete action space, but it is done via the parameter
+`continuous_action_threshold` (i.e. if the "fire" dimension is above `continuous_action_threshold`, a "fire" event is triggered).
+See [[3]](#3) for more details.
+
 ## Observation Space
 
 The Atari environments observation can be
@@ -357,3 +369,10 @@ Machado et al.
 and Open Problems for General Agents"
 Journal of Artificial Intelligence Research (2018)
 URL: https://jair.org/index.php/jair/article/view/11182
+
+(#3)=
+<a id="3">[3]</a>
+Jesse Farebrother and Pablo Samuel Castro
+"CALE: Continuous Arcade Learning Environment"
+Advances in Neural Information Processing Systems (NeurIPS 2024)
+URL: https://arxiv.org/abs/2410.23810


### PR DESCRIPTION
Adding instructions for how to use CALE (Continuous ALE), as well as citation instructions.

Will also add instructions to https://ale.farama.org/environments/.