### PR TITLE
Use system CMake if available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,6 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
 
-    - name: Install windows cmake
-      # TODO(jfarebro): There's a bug with Windows cmake and PEP517 builds via pip install.
-      # As a temporary workaround installing cmake outside of the isolated env seems to work.
-      run: python -m pip install --user cmake
-      if: runner.os == 'Windows'
-
     - name: Download and unpack ROMs
       run: ./scripts/download_unpack_roms.sh
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "setuptools>=61",
-    "cmake>=3.22",
-    "ninja; sys_platform != 'win32' and platform_machine != 'arm64'",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Instead of depending on `cmake` and `ninja` executables unconditionally, add these dependencies only if system executables are not available. This ensures that system CMake is used when available (instead of being overridden by the PyPI build of CMake), so the user can benefit from improved portability due to downstream patching and avoids unnecessary dependencies.

This also adjusts the generator choice to support system `ninja` install, i.e. one without a `ninja` module.