### PR TITLE
Add ALE vector implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "external/ThreadPool"]
+	path = external/ThreadPool
+	url = https://github.com/progschj/ThreadPool
+[submodule "external/concurrentqueue"]
+	path = external/concurrentqueue
+	url = https://github.com/cameron314/concurrentqueue

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ if(SDL_SUPPORT)
   list(APPEND VCPKG_MANIFEST_FEATURES "sdl")
 endif()
 
+option(BUILD_VECTOR_LIB "Build Vector Interface" OFF)
+if (BUILD_VECTOR_LIB)
+  list(APPEND VCPKG_MANIFEST_FEATURES "vector")
+endif()
+
 # Set cmake module path
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ test = [
 
 [project.urls]
 homepage = "https://github.com/Farama-Foundation/Arcade-Learning-Environment"
-documentation = "https://github.com/Farama-Foundation/Arcade-Learning-Environment/tree/master/docs"
+documentation = "https://ale.farama.org"
 changelog = "https://github.com/Farama-Foundation/Arcade-Learning-Environment/blob/master/CHANGELOG.md"
 
 [tool.setuptools]

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ class CMakeBuild(build_ext):
             "-DSDL_DYNLOAD=ON",
             "-DBUILD_CPP_LIB=OFF",
             "-DBUILD_PYTHON_LIB=ON",
+            "-DBUILD_VECTOR_LIB=ON",
         ]
         build_args = []
 

--- a/src/ale/CMakeLists.txt
+++ b/src/ale/CMakeLists.txt
@@ -58,6 +58,18 @@ if (BUILD_CPP_LIB OR BUILD_PYTHON_LIB)
   add_library(ale-lib ale_interface.cpp)
   set_target_properties(ale-lib PROPERTIES OUTPUT_NAME ale)
   target_link_libraries(ale-lib PUBLIC ale)
+
+  if (BUILD_VECTOR_LIB)
+    find_package(OpenCV CONFIG REQUIRED)
+    target_link_directories(ale PRIVATE opencv_core)
+
+    target_include_directories(ale PUBLIC
+      ${PROJECT_SOURCE_DIR}/external/concurrentqueue/
+      ${PROJECT_SOURCE_DIR}/external/ThreadPool/
+    )
+
+    add_subdirectory(vector)
+  endif()
 endif()
 
 # Python Library

--- a/src/ale/CMakeLists.txt
+++ b/src/ale/CMakeLists.txt
@@ -61,7 +61,7 @@ if (BUILD_CPP_LIB OR BUILD_PYTHON_LIB)
 
   if (BUILD_VECTOR_LIB)
     find_package(OpenCV CONFIG REQUIRED)
-    target_link_directories(ale PRIVATE opencv_core)
+    include_directories(${OpenCV_INCLUDE_DIRS})
 
     target_include_directories(ale PUBLIC
       ${PROJECT_SOURCE_DIR}/external/concurrentqueue/
@@ -69,6 +69,8 @@ if (BUILD_CPP_LIB OR BUILD_PYTHON_LIB)
     )
 
     add_subdirectory(vector)
+
+    target_link_libraries(ale PRIVATE ${OpenCV_LIBS})
   endif()
 endif()
 

--- a/src/ale/python/CMakeLists.txt
+++ b/src/ale/python/CMakeLists.txt
@@ -14,7 +14,13 @@ if(NOT pybind11_FOUND)
     FetchContent_MakeAvailable(pybind11)
 endif()
 
-add_library(ale-py MODULE ale_python_interface.cpp)
+# If vector library is enabled, include the vector Python interface
+if(BUILD_VECTOR_LIB)
+    add_library(ale-py MODULE ale_python_interface.cpp ale_vector_python_interface.cpp)
+else ()
+    add_library(ale-py MODULE ale_python_interface.cpp )
+endif()
+
 # Depend on the ALE and pybind11 module
 target_link_libraries(ale-py PUBLIC ale ale-lib)
 target_link_libraries(ale-py PRIVATE pybind11::module)

--- a/src/ale/python/ale_python_interface.hpp
+++ b/src/ale/python/ale_python_interface.hpp
@@ -211,6 +211,11 @@ PYBIND11_MODULE(_ale_py, m) {
       .def("restoreSystemState", &ale::ALEPythonInterface::restoreSystemState)
       .def("saveScreenPNG", &ale::ALEPythonInterface::saveScreenPNG)
       .def_static("setLoggerMode", &ale::Logger::setMode);
+
+  // Initialize the vector module if it's enabled
+#ifdef BUILD_VECTOR_LIB
+  init_vector_module(m);
+#endif
 }
 
 #endif // __ALE_PYTHON_INTERFACE_HPP__

--- a/src/ale/python/ale_vector_python_interface.cpp
+++ b/src/ale/python/ale_vector_python_interface.cpp
@@ -1,0 +1,77 @@
+#include "ale_vector_python_interface.hpp"
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+
+namespace py = pybind11;
+
+
+// Python module definition
+PYBIND11_MODULE(_vector, m) {
+    // Module docstring
+    m.doc() = "Vector environment support for ALE";
+
+    // Define ActionSlice class
+    py::class_<ActionSlice>(m, "ActionSlice")
+        .def(py::init<>())
+        .def_readwrite("env_id", &ActionSlice::env_id)
+        .def_readwrite("order", &ActionSlice::order)
+        .def_readwrite("force_reset", &ActionSlice::force_reset);
+
+    // Define Action class
+    py::class_<Action>(m, "Action")
+        .def(py::init<>())
+        .def(py::init([](const py::dict& d) {
+            Action a;
+            a.env_id = d["env_id"].cast<int>();
+            a.action_id = d["action_id"].cast<int>();
+            if (d.contains("paddle_strength")) {
+                a.paddle_strength = d["paddle_strength"].cast<float>();
+            } else {
+                a.paddle_strength = 1.0f;
+            }
+            return a;
+        }))
+        .def_readwrite("env_id", &Action::env_id)
+        .def_readwrite("action_id", &Action::action_id)
+        .def_readwrite("paddle_strength", &Action::paddle_strength);
+
+    // Define Observation class
+    py::class_<Observation>(m, "Observation")
+        .def(py::init<>())
+        .def_property_readonly("env_id", [](const Observation& o) { return o.env_id; })
+        .def_property_readonly("screen", [](const Observation& o) { return o.screen; })
+        .def_property_readonly("reward", [](const Observation& o) { return o.reward; })
+        .def_property_readonly("done", [](const Observation& o) { return o.done; })
+        .def_property_readonly("truncated", [](const Observation& o) { return o.truncated; })
+        .def_property_readonly("lives", [](const Observation& o) { return o.lives; })
+        .def_property_readonly("frame_number", [](const Observation& o) { return o.frame_number; })
+        .def_property_readonly("episode_frame_number", [](const Observation& o) { return o.episode_frame_number; });
+
+    // Define ALEVectorInterface class
+    py::class_<ALEVectorInterface>(m, "ALEVectorInterface")
+        .def(py::init<int, const std::string&, int, bool, int, int, int, int, bool, bool, int, float, bool, int, int, int, int>(),
+             py::arg("num_envs"),
+             py::arg("rom_path"),
+             py::arg("frame_skip") = 4,
+             py::arg("gray_scale") = true,
+             py::arg("stack_num") = 4,
+             py::arg("img_height") = 84,
+             py::arg("img_width") = 84,
+             py::arg("noop_max") = 30,
+             py::arg("fire_reset") = true,
+             py::arg("episodic_life") = false,
+             py::arg("max_episode_steps") = 108000,
+             py::arg("repeat_action_probability") = 0.0f,
+             py::arg("full_action_space") = false,
+             py::arg("batch_size") = 0,
+             py::arg("num_threads") = 0,
+             py::arg("seed") = 0,
+             py::arg("thread_affinity_offset") = -1)
+        .def("reset_all", &ALEVectorInterface::reset_all)
+        .def("reset", &ALEVectorInterface::reset)
+        .def("step", &ALEVectorInterface::step)
+        .def("get_action_set", &ALEVectorInterface::get_action_set)
+        .def("get_num_envs", &ALEVectorInterface::get_num_envs)
+        .def("get_observation_dims", &ALEVectorInterface::get_observation_dims);
+}

--- a/src/ale/python/ale_vector_python_interface.cpp
+++ b/src/ale/python/ale_vector_python_interface.cpp
@@ -5,24 +5,23 @@
 
 namespace py = pybind11;
 
-
-// Python module definition
-PYBIND11_MODULE(_vector, m) {
-    // Module docstring
-    m.doc() = "Vector environment support for ALE";
+// Function to add vector environment bindings to an existing module
+void init_vector_module(py::module& m) {
+    // Create a submodule for vector environments
+    py::module vector_module = m.def_submodule("vector", "Vector environment support for ALE");
 
     // Define ActionSlice class
-    py::class_<ActionSlice>(m, "ActionSlice")
+    py::class_<ale::vector::ActionSlice>(vector_module, "ActionSlice")
         .def(py::init<>())
-        .def_readwrite("env_id", &ActionSlice::env_id)
-        .def_readwrite("order", &ActionSlice::order)
-        .def_readwrite("force_reset", &ActionSlice::force_reset);
+        .def_readwrite("env_id", &ale::vector::ActionSlice::env_id)
+        .def_readwrite("order", &ale::vector::ActionSlice::order)
+        .def_readwrite("force_reset", &ale::vector::ActionSlice::force_reset);
 
     // Define Action class
-    py::class_<Action>(m, "Action")
+    py::class_<ale::vector::Action>(vector_module, "Action")
         .def(py::init<>())
         .def(py::init([](const py::dict& d) {
-            Action a;
+            ale::vector::Action a;
             a.env_id = d["env_id"].cast<int>();
             a.action_id = d["action_id"].cast<int>();
             if (d.contains("paddle_strength")) {
@@ -32,24 +31,24 @@ PYBIND11_MODULE(_vector, m) {
             }
             return a;
         }))
-        .def_readwrite("env_id", &Action::env_id)
-        .def_readwrite("action_id", &Action::action_id)
-        .def_readwrite("paddle_strength", &Action::paddle_strength);
+        .def_readwrite("env_id", &ale::vector::Action::env_id)
+        .def_readwrite("action_id", &ale::vector::Action::action_id)
+        .def_readwrite("paddle_strength", &ale::vector::Action::paddle_strength);
 
     // Define Observation class
-    py::class_<Observation>(m, "Observation")
+    py::class_<ale::vector::Observation>(vector_module, "Observation")
         .def(py::init<>())
-        .def_property_readonly("env_id", [](const Observation& o) { return o.env_id; })
-        .def_property_readonly("screen", [](const Observation& o) { return o.screen; })
-        .def_property_readonly("reward", [](const Observation& o) { return o.reward; })
-        .def_property_readonly("done", [](const Observation& o) { return o.done; })
-        .def_property_readonly("truncated", [](const Observation& o) { return o.truncated; })
-        .def_property_readonly("lives", [](const Observation& o) { return o.lives; })
-        .def_property_readonly("frame_number", [](const Observation& o) { return o.frame_number; })
-        .def_property_readonly("episode_frame_number", [](const Observation& o) { return o.episode_frame_number; });
+        .def_property_readonly("env_id", [](const ale::vector::Observation& o) { return o.env_id; })
+        .def_property_readonly("screen", [](const ale::vector::Observation& o) { return o.screen; })
+        .def_property_readonly("reward", [](const ale::vector::Observation& o) { return o.reward; })
+        .def_property_readonly("terminated", [](const ale::vector::Observation& o) { return o.terminated; })
+        .def_property_readonly("truncated", [](const ale::vector::Observation& o) { return o.truncated; })
+        .def_property_readonly("lives", [](const ale::vector::Observation& o) { return o.lives; })
+        .def_property_readonly("frame_number", [](const ale::vector::Observation& o) { return o.frame_number; })
+        .def_property_readonly("episode_frame_number", [](const ale::vector::Observation& o) { return o.episode_frame_number; });
 
     // Define ALEVectorInterface class
-    py::class_<ALEVectorInterface>(m, "ALEVectorInterface")
+    py::class_<ale::vector::ALEVectorInterface>(vector_module, "ALEVectorInterface")
         .def(py::init<int, const std::string&, int, bool, int, int, int, int, bool, bool, int, float, bool, int, int, int, int>(),
              py::arg("num_envs"),
              py::arg("rom_path"),
@@ -68,10 +67,9 @@ PYBIND11_MODULE(_vector, m) {
              py::arg("num_threads") = 0,
              py::arg("seed") = 0,
              py::arg("thread_affinity_offset") = -1)
-        .def("reset_all", &ALEVectorInterface::reset_all)
-        .def("reset", &ALEVectorInterface::reset)
-        .def("step", &ALEVectorInterface::step)
-        .def("get_action_set", &ALEVectorInterface::get_action_set)
-        .def("get_num_envs", &ALEVectorInterface::get_num_envs)
-        .def("get_observation_dims", &ALEVectorInterface::get_observation_dims);
+        .def("reset", &ale::vector::ALEVectorInterface::reset)
+        .def("step", &ale::vector::ALEVectorInterface::step)
+        .def("get_action_set", &ale::vector::ALEVectorInterface::get_action_set)
+        .def("get_num_envs", &ale::vector::ALEVectorInterface::get_num_envs)
+        .def("get_observation_shape", &ale::vector::ALEVectorInterface::get_observation_shape);
 }

--- a/src/ale/python/ale_vector_python_interface.hpp
+++ b/src/ale/python/ale_vector_python_interface.hpp
@@ -117,22 +117,11 @@ public:
      *
      * @return Observations from all environments after reset
      */
-    std::vector<Observation> reset_all() {
+    std::vector<Observation> reset() {
         std::vector<int> env_ids(num_envs_);
         for (int i = 0; i < num_envs_; ++i) {
             env_ids[i] = i;
         }
-        vectorizer_->reset(env_ids);
-        return vectorizer_->recv();
-    }
-
-    /**
-     * Reset specific environments
-     *
-     * @param env_ids IDs of environments to reset
-     * @return Observations from reset environments
-     */
-    std::vector<Observation> reset(const std::vector<int>& env_ids) {
         vectorizer_->reset(env_ids);
         return vectorizer_->recv();
     }
@@ -171,7 +160,7 @@ public:
      *
      * @return Tuple of (stack_num, channels, height, width)
      */
-    std::tuple<int, int, int, int> get_observation_dims() const {
+    std::tuple<int, int, int, int> get_observation_shape() const {
         const int channels = gray_scale_ ? 1 : 3;
         return std::make_tuple(stack_num_, channels, img_height_, img_width_);
     }

--- a/src/ale/python/ale_vector_python_interface.hpp
+++ b/src/ale/python/ale_vector_python_interface.hpp
@@ -1,0 +1,203 @@
+#ifndef ALE_VECTOR_INTERFACE_HPP_
+#define ALE_VECTOR_INTERFACE_HPP_
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <random>
+#include <filesystem>
+
+#include "ale/vector/async_vectorizer.hpp"
+#include "ale/vector/preprocessed_env.hpp"
+#include "ale/vector/utils.hpp"
+
+namespace fs = std::filesystem;
+
+namespace ale {
+namespace vector {
+
+/**
+ * ALEVectorInterface provides a vectorized interface to the Arcade Learning Environment.
+ * It manages multiple Atari environments running in parallel and allows sending actions
+ * and receiving observations in batches.
+ */
+class ALEVectorInterface {
+public:
+    /**
+     * Constructor
+     *
+     * @param num_envs Number of parallel environments
+     * @param rom_path Path to the ROM file
+     * @param frame_skip Number of frames to skip between agent decisions (default: 4)
+     * @param gray_scale Whether to convert frames to grayscale (default: true)
+     * @param stack_num Number of frames to stack for observations (default: 4)
+     * @param img_height Height to resize frames to (default: 84)
+     * @param img_width Width to resize frames to (default: 84)
+     * @param noop_max Maximum number of no-ops to perform at reset (default: 30)
+     * @param fire_reset Whether to press FIRE during reset (default: true)
+     * @param episodic_life Whether to end episodes when a life is lost (default: false)
+     * @param max_episode_steps Maximum number of steps per episode (default: 108000)
+     * @param repeat_action_probability Probability of repeating the last action (default: 0.0f)
+     * @param full_action_space Whether to use the full action space (default: false)
+     * @param batch_size The number of environments to process in a batch (0 means use num_envs, default: 0)
+     * @param num_threads The number of worker threads to use (0 means use hardware concurrency, default: 0)
+     * @param seed Random seed (default: 0)
+     * @param thread_affinity_offset The CPU core offset for thread affinity (-1 means no affinity, default: -1)
+     */
+    ALEVectorInterface(
+        int num_envs,
+        const std::string& rom_path,
+        int frame_skip = 4,
+        bool gray_scale = true,
+        int stack_num = 4,
+        int img_height = 84,
+        int img_width = 84,
+        int noop_max = 30,
+        bool fire_reset = true,
+        bool episodic_life = false,
+        int max_episode_steps = 108000,
+        float repeat_action_probability = 0.0f,
+        bool full_action_space = false,
+        int batch_size = 0,
+        int num_threads = 0,
+        int seed = 0,
+        int thread_affinity_offset = -1
+    ) : num_envs_(num_envs),
+        rom_path_(rom_path),
+        frame_skip_(frame_skip),
+        gray_scale_(gray_scale),
+        stack_num_(stack_num),
+        img_height_(img_height),
+        img_width_(img_width),
+        noop_max_(noop_max),
+        fire_reset_(fire_reset),
+        episodic_life_(episodic_life),
+        max_episode_steps_(max_episode_steps),
+        repeat_action_probability_(repeat_action_probability),
+        full_action_space_(full_action_space),
+        seed_(seed),
+        gen_(seed) {
+
+        // Create environment factory
+        auto env_factory = [this](int env_id) {
+            return std::make_unique<PreprocessedAtariEnv>(
+                env_id,
+                rom_path_,
+                frame_skip_,
+                gray_scale_,
+                stack_num_,
+                img_height_,
+                img_width_,
+                noop_max_,
+                fire_reset_,
+                episodic_life_,
+                max_episode_steps_,
+                repeat_action_probability_,
+                full_action_space_,
+                seed_ + env_id
+            );
+        };
+
+        // Create vectorizer
+        vectorizer_ = std::make_unique<AsyncVectorizer>(
+            num_envs,
+            batch_size,
+            num_threads,
+            thread_affinity_offset,
+            env_factory
+        );
+
+        // Initialize action set (assuming all environments have the same action set)
+        auto temp_env = env_factory(0);
+        action_set_ = temp_env->get_action_set();
+    }
+
+    /**
+     * Reset all environments
+     *
+     * @return Observations from all environments after reset
+     */
+    std::vector<Observation> reset_all() {
+        std::vector<int> env_ids(num_envs_);
+        for (int i = 0; i < num_envs_; ++i) {
+            env_ids[i] = i;
+        }
+        vectorizer_->reset(env_ids);
+        return vectorizer_->recv();
+    }
+
+    /**
+     * Reset specific environments
+     *
+     * @param env_ids IDs of environments to reset
+     * @return Observations from reset environments
+     */
+    std::vector<Observation> reset(const std::vector<int>& env_ids) {
+        vectorizer_->reset(env_ids);
+        return vectorizer_->recv();
+    }
+
+    /**
+     * Step environments with actions
+     *
+     * @param actions Vector of actions to take in environments
+     * @return Observations from environments after stepping
+     */
+    std::vector<Observation> step(const std::vector<Action>& actions) {
+        vectorizer_->send(actions);
+        return vectorizer_->recv();
+    }
+
+    /**
+     * Get the available actions for the environments
+     *
+     * @return Vector of available actions
+     */
+    const ActionVect& get_action_set() const {
+        return action_set_;
+    }
+
+    /**
+     * Get the number of environments
+     *
+     * @return Number of environments
+     */
+    int get_num_envs() const {
+        return num_envs_;
+    }
+
+    /**
+     * Get the dimensions of the observation space
+     *
+     * @return Tuple of (stack_num, channels, height, width)
+     */
+    std::tuple<int, int, int, int> get_observation_dims() const {
+        const int channels = gray_scale_ ? 1 : 3;
+        return std::make_tuple(stack_num_, channels, img_height_, img_width_);
+    }
+
+private:
+    int num_envs_;                            // Number of parallel environments
+    std::string rom_path_;                    // Path to the ROM file
+    int frame_skip_;                          // Number of frames to skip
+    bool gray_scale_;                         // Whether to use grayscale
+    int stack_num_;                           // Number of frames to stack
+    int img_height_;                          // Height of resized frames
+    int img_width_;                           // Width of resized frames
+    int noop_max_;                            // Max no-ops on reset
+    bool fire_reset_;                         // Whether to fire on reset
+    bool episodic_life_;                      // End episode on life loss
+    int max_episode_steps_;                   // Max steps per episode
+    float repeat_action_probability_;         // Sticky actions probability
+    bool full_action_space_;                  // Use full action space
+    int seed_;                                // Random seed
+    std::mt19937 gen_;                        // Random number generator
+
+    std::unique_ptr<AsyncVectorizer> vectorizer_;  // Vectorizer
+    ActionVect action_set_;                  // Set of available actions
+};
+
+} // namespace vector
+} // namespace ale
+
+#endif // ALE_VECTOR_INTERFACE_HPP_

--- a/src/ale/vector/CMakeLists.txt
+++ b/src/ale/vector/CMakeLists.txt
@@ -1,0 +1,6 @@
+target_sources(ale
+    PRIVATE
+        preprocessed_env.hpp
+        async_vectorizer.hpp
+        utils.hpp
+)

--- a/src/ale/vector/async_vectorizer.hpp
+++ b/src/ale/vector/async_vectorizer.hpp
@@ -15,6 +15,10 @@
 #include "utils.hpp"
 #include "preprocessed_env.hpp"
 
+#if defined(_WIN32) || defined(WIN32) || defined(_MSC_VER)
+    #include <windows.h>
+#endif
+
 namespace ale {
 namespace vector {
 
@@ -56,7 +60,7 @@ public:
         // Setup worker threads
         std::size_t processor_count = std::thread::hardware_concurrency();
         if (num_threads <= 0) {
-            num_threads_ = std::min(batch_size_, static_cast<int>(processor_count));
+            num_threads_ = min(batch_size_, static_cast<int>(processor_count));
         } else {
             num_threads_ = num_threads;
         }
@@ -102,11 +106,11 @@ public:
             int env_id = actions[i].env_id;
             envs_[env_id]->set_action(actions[i]);
 
-            action_slices.emplace_back(ActionSlice{
-                .env_id = env_id,
-                .order = is_sync_ ? static_cast<int>(i) : -1,
-                .force_reset = false
-            });
+            ActionSlice slice;
+            slice.env_id = env_id;
+            slice.order = is_sync_ ? static_cast<int>(i) : -1;
+            slice.force_reset = false;
+            action_slices.emplace_back(slice);
         }
 
         if (is_sync_) {
@@ -146,11 +150,11 @@ public:
         reset_actions.reserve(env_ids.size());
 
         for (size_t i = 0; i < env_ids.size(); ++i) {
-            reset_actions.emplace_back(ActionSlice{
-                .env_id = env_ids[i],
-                .order = is_sync_ ? static_cast<int>(i) : -1,
-                .force_reset = true
-            });
+            ActionSlice slice;
+            slice.env_id = env_ids[i];
+            slice.order = is_sync_ ? static_cast<int>(i) : -1;
+            slice.force_reset = true;
+            reset_actions.emplace_back(slice);
         }
 
         if (is_sync_) {

--- a/src/ale/vector/async_vectorizer.hpp
+++ b/src/ale/vector/async_vectorizer.hpp
@@ -1,0 +1,236 @@
+#ifndef ALE_VECTOR_ASYNC_VECTORIZER_HPP_
+#define ALE_VECTOR_ASYNC_VECTORIZER_HPP_
+
+#include <vector>
+#include <memory>
+#include <thread>
+#include <atomic>
+#include <functional>
+#include <mutex>
+#include <condition_variable>
+#include <array>
+#include <cstdint>
+
+#include "ThreadPool.h"
+#include "utils.hpp"
+#include "preprocessed_env.hpp"
+
+namespace ale {
+namespace vector {
+
+/**
+ * AsyncVectorizer manages a collection of environments that can be stepped in parallel.
+ * It handles the distribution of actions to environments and collection of observations.
+ */
+class AsyncVectorizer {
+public:
+    /**
+     * Constructor for AsyncVectorizer
+     *
+     * @param num_envs The number of parallel environments to run
+     * @param batch_size The number of environments to process in a batch (0 means use num_envs)
+     * @param num_threads The number of worker threads to use (0 means use hardware concurrency)
+     * @param thread_affinity_offset The CPU core offset for thread affinity (-1 means no affinity)
+     * @param env_factory Function that creates environment instances
+     */
+    AsyncVectorizer(
+        int num_envs,
+        int batch_size = 0,
+        int num_threads = 0,
+        int thread_affinity_offset = -1,
+        std::function<std::unique_ptr<PreprocessedAtariEnv>(int)> env_factory = nullptr
+    ) : num_envs_(num_envs),
+        batch_size_(batch_size <= 0 ? num_envs : batch_size),
+        is_sync_(batch_size_ == num_envs_),
+        stop_(false),
+        stepping_env_num_(0),
+        action_buffer_queue_(new ActionBufferQueue(num_envs_)),
+        state_buffer_queue_(new StateBufferQueue(batch_size_, num_envs_)) {
+
+        // Create environments
+        envs_.resize(num_envs_);
+        for (int i = 0; i < num_envs_; ++i) {
+            envs_[i] = env_factory(i);
+        }
+
+        // Setup worker threads
+        std::size_t processor_count = std::thread::hardware_concurrency();
+        if (num_threads <= 0) {
+            num_threads_ = std::min(batch_size_, static_cast<int>(processor_count));
+        } else {
+            num_threads_ = num_threads;
+        }
+
+        // Start worker threads
+        for (int i = 0; i < num_threads_; ++i) {
+            workers_.emplace_back([this] {
+                worker_function();
+            });
+        }
+
+        // Set thread affinity if requested
+        if (thread_affinity_offset >= 0) {
+            set_thread_affinity(thread_affinity_offset, processor_count);
+        }
+    }
+
+    /**
+     * Destructor - stops worker threads and cleans up resources
+     */
+    ~AsyncVectorizer() {
+        stop_ = true;
+        // Send empty actions to wake up and terminate all worker threads
+        std::vector<ActionSlice> empty_actions(workers_.size());
+        action_buffer_queue_->enqueue_bulk(empty_actions);
+        for (auto& worker : workers_) {
+            if (worker.joinable()) {
+                worker.join();
+            }
+        }
+    }
+
+    /**
+     * Send actions to environments
+     *
+     * @param actions Vector of actions to send to environments
+     */
+    void send(const std::vector<Action>& actions) {
+        std::vector<ActionSlice> action_slices;
+        action_slices.reserve(actions.size());
+
+        for (size_t i = 0; i < actions.size(); ++i) {
+            int env_id = actions[i].env_id;
+            envs_[env_id]->set_action(actions[i]);
+
+            action_slices.emplace_back(ActionSlice{
+                .env_id = env_id,
+                .order = is_sync_ ? static_cast<int>(i) : -1,
+                .force_reset = false
+            });
+        }
+
+        if (is_sync_) {
+            stepping_env_num_ += actions.size();
+        }
+
+        action_buffer_queue_->enqueue_bulk(action_slices);
+    }
+
+    /**
+     * Receive observations from environments
+     *
+     * @return Vector of observations from environments
+     */
+    std::vector<Observation> recv() {
+        int additional_wait = 0;
+        if (is_sync_ && stepping_env_num_ < batch_size_) {
+            additional_wait = batch_size_ - stepping_env_num_;
+        }
+
+        std::vector<Observation> observations = state_buffer_queue_->wait(additional_wait);
+
+        if (is_sync_) {
+            stepping_env_num_ -= observations.size();
+        }
+
+        return observations;
+    }
+
+    /**
+     * Reset specified environments
+     *
+     * @param env_ids Vector of environment IDs to reset
+     */
+    void reset(const std::vector<int>& env_ids) {
+        std::vector<ActionSlice> reset_actions;
+        reset_actions.reserve(env_ids.size());
+
+        for (size_t i = 0; i < env_ids.size(); ++i) {
+            reset_actions.emplace_back(ActionSlice{
+                .env_id = env_ids[i],
+                .order = is_sync_ ? static_cast<int>(i) : -1,
+                .force_reset = true
+            });
+        }
+
+        if (is_sync_) {
+            stepping_env_num_ += env_ids.size();
+        }
+
+        action_buffer_queue_->enqueue_bulk(reset_actions);
+    }
+
+private:
+    /**
+     * Worker thread function that processes environment steps
+     */
+    void worker_function() {
+        while (!stop_) {
+            try {
+                ActionSlice action = action_buffer_queue_->dequeue();
+                if (stop_) {
+                    break;
+                }
+
+                int env_id = action.env_id;
+                int order = action.order;
+                bool reset = action.force_reset || envs_[env_id]->is_episode_over();
+
+                if (reset) {
+                    envs_[env_id]->reset();
+                } else {
+                    envs_[env_id]->step();
+                }
+
+                // Get observation and write to state buffer
+                Observation obs = envs_[env_id]->get_observation();
+                state_buffer_queue_->write(obs, order);
+
+            } catch (const std::exception& e) {
+                // Log error but continue processing
+                std::cerr << "Error in worker thread: " << e.what() << std::endl;
+            }
+        }
+    }
+
+    /**
+     * Set thread affinity for worker threads
+     */
+    void set_thread_affinity(int thread_affinity_offset, int processor_count) {
+        for (size_t tid = 0; tid < workers_.size(); ++tid) {
+            size_t core_id = (thread_affinity_offset + tid) % processor_count;
+
+            #if defined(__linux__)
+                cpu_set_t cpuset;
+                CPU_ZERO(&cpuset);
+                CPU_SET(core_id, &cpuset);
+                pthread_setaffinity_np(workers_[tid].native_handle(), sizeof(cpu_set_t), &cpuset);
+            #elif defined(_WIN32)
+                DWORD_PTR mask = (static_cast<DWORD_PTR>(1) << core_id);
+                SetThreadAffinityMask(workers_[tid].native_handle(), mask);
+            #elif defined(__APPLE__)
+                thread_affinity_policy_data_t policy = { static_cast<integer_t>(core_id) };
+                thread_port_t mach_thread = pthread_mach_thread_np(workers_[tid].native_handle());
+                thread_policy_set(mach_thread, THREAD_AFFINITY_POLICY,
+                                (thread_policy_t)&policy, THREAD_AFFINITY_POLICY_COUNT);
+            #endif
+        }
+    }
+
+private:
+    int num_envs_;                                    // Number of parallel environments
+    int batch_size_;                                  // Batch size for processing
+    int num_threads_;                                 // Number of worker threads
+    bool is_sync_;                                    // Whether to operate in synchronous mode
+    std::atomic<bool> stop_;                          // Signal to stop worker threads
+    std::atomic<int> stepping_env_num_;               // Number of environments currently stepping
+    std::vector<std::thread> workers_;                // Worker threads
+    std::unique_ptr<ActionBufferQueue> action_buffer_queue_;  // Queue for actions
+    std::unique_ptr<StateBufferQueue> state_buffer_queue_;    // Queue for observations
+    std::vector<std::unique_ptr<PreprocessedAtariEnv>> envs_; // Environment instances
+};
+
+} // namespace vector
+} // namespace ale
+
+#endif // ALE_VECTOR_ASYNC_VECTORIZER_HPP_

--- a/src/ale/vector/preprocessed_env.hpp
+++ b/src/ale/vector/preprocessed_env.hpp
@@ -1,0 +1,346 @@
+#ifndef ALE_VECTOR_ATARI_ENV_HPP_
+#define ALE_VECTOR_ATARI_ENV_HPP_
+
+#include <memory>
+#include <vector>
+#include <deque>
+#include <random>
+#include <string>
+#include <algorithm>
+
+#include <opencv2/opencv.hpp>
+
+#include "ale/ale_interface.hpp"
+#include "utils.hpp"
+
+namespace ale {
+namespace vector {
+
+/**
+ * PreprocessedAtariEnv encapsulates a single Atari environment using the ALE Interface with standard preprocessing and stacking.
+ */
+class PreprocessedAtariEnv {
+public:
+    /**
+     * Constructor
+     *
+     * @param env_id Unique ID for this environment instance
+     * @param rom_path Path to the ROM file
+     * @param obs_height Height to resize frames to for observations
+     * @param obs_width Width to resize frames to for observations
+     * @param frame_skip Number of frames for which to repeat the action
+     * @param gray_scale Whether to convert frames to grayscale observation or keep RGB
+     * @param maxpool Whether to maxpool observations
+     * @param stack_num Number of frames to stack for observations
+     * @param noop_max Maximum number of no-ops to perform on resets
+     * @param fire_reset Whether to press FIRE during reset
+     * @param episodic_life Whether to end episodes when a life is lost
+     * @param max_episode_steps Maximum number of steps per episode before truncating
+     * @param repeat_action_probability Probability of repeating the last action
+     * @param full_action_space Whether to use the full action space
+     * @param seed Random seed
+     */
+    PreprocessedAtariEnv(
+        int env_id,
+        const std::string& rom_path,
+        int obs_height = 84,
+        int obs_width = 84,
+        int frame_skip = 4,
+        bool gray_scale = true,
+        bool maxpool = true,
+        int stack_num = 4,
+        int noop_max = 30,
+        bool fire_reset = true,
+        bool episodic_life = false,
+        int max_episode_steps = 108000,
+        float repeat_action_probability = 0.0f,
+        bool full_action_space = false,
+        int seed = 0
+    ) : env_id_(env_id),
+        rom_path_(rom_path),
+        frame_skip_(frame_skip),
+        obs_height_(obs_height),
+        obs_width_(obs_width),
+        gray_scale_(gray_scale),
+        maxpool_(maxpool),
+        stack_num_(stack_num),
+        noop_max_(noop_max),
+        fire_reset_(fire_reset),
+        episodic_life_(episodic_life),
+        max_episode_steps_(max_episode_steps),
+        elapsed_step_(max_episode_steps + 1),
+        seed_(seed + env_id),
+        rng_gen_(seed_) {
+
+        // Turn off verbosity
+        Logger::setMode(Logger::Error);
+
+        // Initialize ALE
+        env_ = std::make_unique<ALEInterface>();
+        env_->setFloat("repeat_action_probability", repeat_action_probability);
+        env_->setInt("random_seed", seed_);
+        env_->loadROM(rom_path_);
+
+        // Get action set
+        if (full_action_space) {
+            action_set_ = env_->getLegalActionSet();
+        } else {
+            action_set_ = env_->getMinimalActionSet();
+        }
+
+        // Check if fire action is available (needed for fire_reset)
+        if (fire_reset_) {
+            has_fire_action_ = false;
+            for (auto a : action_set_) {
+                if (a == PLAYER_A_FIRE) {
+                    has_fire_action_ = true;
+                    break;
+                }
+            }
+            fire_reset_ = has_fire_action_;
+        }
+
+        // Initialize random distribution for no-ops
+        noop_generator_ = std::uniform_int_distribution<>(0, noop_max_ - 1);
+
+        // Initialize the buffers
+        const int channels = gray_scale_ ? 1 : 3;
+        for (int i = 0; i < 2; ++i) {
+            raw_frames_.emplace_back(210 * 160 * channels);
+        }
+        resized_frame_.resize(obs_height_ * obs_width_ * channels);
+        for (int i = 0; i < stack_num_; ++i) {
+            std::vector<uint8_t> frame(obs_height_ * obs_width_ * channels, 0);
+            frame_stack_.push_back(std::move(frame));
+        }
+    }
+
+    /**
+     * Reset the environment and return the initial observation
+     */
+    void reset() {
+        env_->reset_game();
+
+        // Perform no-op steps
+        int noop_steps = noop_generator_(rng_gen_) + 1 - static_cast<int>(fire_reset_ && has_fire_action_);
+        while (noop_steps > 0) {
+            env_->act(PLAYER_A_NOOP);
+            if (env_->game_over()) {
+                env_->reset_game();
+            }
+            noop_steps--;
+        }
+
+        // Press FIRE if required by the environment
+        if (fire_reset_ && has_fire_action_) {
+            env_->act(PLAYER_A_FIRE);
+        }
+
+        // Get the screen data and process it
+        std::fill(raw_frames_[0].begin(), raw_frames_[0].end(), 0);
+        get_screen_data(raw_frames_[1].data());
+        process_screen();
+        for (int stack_id = 0; stack_id < stack_num_ - 1; ++stack_id) {
+            frame_stack_[stack_id] = resized_frame_;
+        }
+
+        // Update state
+        elapsed_step_ = 0;
+        game_over_ = false;
+        lives_ = env_->lives();
+        current_action_.action_id = PLAYER_A_NOOP;
+    }
+
+    /**
+     * Set the action to be taken in the next step
+     */
+    void set_action(const Action& action) {
+        current_action_ = action;
+    }
+
+    /**
+     * Step the environment using the current action
+     */
+    void step() {
+        float reward = 0.0;
+        game_over_ = false;
+
+        int action_id = current_action_.action_id;
+        ale::Action action = (action_id < 0 || action_id >= static_cast<int>(action_set_.size())) ? PLAYER_A_NOOP : action_set_[action_id];
+        float strength = current_action_.paddle_strength;
+
+        // Execute action for frame_skip frames
+        int skip_id = frame_skip_;
+        for (; skip_id > 0 && !game_over_; --skip_id) {
+            reward += env_->act(action, strength);
+
+            game_over_ = env_->game_over();
+            // Handle episodic life
+            if (episodic_life_ && env_->lives() < lives_ && env_->lives() > 0) {
+                game_over_ = true;
+            }
+
+            // Capture last two frames for maxpooling
+            if (skip_id <= 2) {
+                get_screen_data(raw_frames_[2 - skip_id].data());
+            }
+        }
+
+        // Process the screen
+        process_screen();
+
+        // Update state
+        elapsed_step_++;
+        lives_ = env_->lives();
+        last_reward_ = reward;
+    }
+
+    /**
+     * Get the current observation
+     */
+    Observation get_observation() const {
+        Observation obs;
+        obs.env_id = env_id_;
+
+        obs.reward = last_reward_;
+        obs.terminated = game_over_;
+        obs.truncated = elapsed_step_ >= max_episode_steps_;
+
+        obs.lives = lives_;
+        obs.frame_number = env_->getFrameNumber();
+        obs.episode_frame_number = env_->getEpisodeFrameNumber();
+
+        // Combine stacked frames into a single observation
+        const int channels = gray_scale_ ? 1 : 3;
+        const size_t frame_size = obs_height_ * obs_width_ * channels;
+        obs.screen.resize(frame_size * stack_num_);
+
+        for (int i = 0; i < stack_num_; ++i) {
+            std::memcpy(
+                obs.screen.data() + i * frame_size,
+                frame_stack_[i].data(),
+                frame_size
+            );
+        }
+
+        return obs;
+    }
+
+    /**
+     * Check if the episode is over (terminated or truncated)
+     */
+    bool is_episode_over() const {
+        return game_over_ || elapsed_step_ >= max_episode_steps_;
+    }
+
+    /**
+     * Get the list of available actions
+     */
+    const ActionVect& get_action_set() const {
+        return action_set_;
+    }
+
+private:
+    /**
+     * Get the current screen data from ALE
+     */
+    void get_screen_data(uint8_t* buffer) {
+        const ALEScreen& screen = env_->getScreen();
+        uint8_t* ale_screen_data = screen.getArray();
+
+        if (gray_scale_) {
+            // Get grayscale screen
+            env_->theOSystem->colourPalette().applyPaletteGrayscale(
+                buffer, ale_screen_data, screen.width() * screen.height()
+            );
+        } else {
+            // Get RGB screen
+            env_->theOSystem->colourPalette().applyPaletteRGB(
+                buffer, ale_screen_data, screen.width() * screen.height()
+            );
+        }
+    }
+
+    /**
+     * Process the screen and update the frame stack
+     *
+    * @param maxpool Whether to maxpool the last two raw frames
+     * @param push_all Whether to copy the newest frame to all frames in the stack
+     */
+    void process_screen() {
+        const int channels = gray_scale_ ? 1 : 3;
+        const int raw_height = 210;
+        const int raw_width = 160;
+
+        if (maxpool_) {
+            // Maxpool over the last two frames
+            const int raw_size = raw_height * raw_width * channels;
+            for (int i = 0; i < raw_size; ++i) {
+                raw_frames_[0][i] = std::max(raw_frames_[0][i], raw_frames_[1][i]);
+            }
+        }
+
+        // Resize the raw frame to target dimensions
+        resize_frame(
+            raw_frames_[0].data(),
+            resized_frame_.data(),
+            raw_height,
+            raw_width,
+            obs_height_,
+            obs_width_,
+            channels
+        );
+
+        // Push the new frame into the stack
+        frame_stack_.pop_front();
+        frame_stack_.push_back(resized_frame_);
+    }
+
+    /**
+     * Resize a frame from raw resolution to target resolution
+     */
+    void resize_frame(const uint8_t* src, uint8_t* dst, int src_h, int src_w, int dst_h, int dst_w, int channels) {
+        cv::Mat src_img(src_h, src_w, channels == 1 ? CV_8UC1 : CV_8UC3, const_cast<uint8_t*>(src));
+        cv::Mat dst_img(dst_h, dst_w, channels == 1 ? CV_8UC1 : CV_8UC3, dst);
+
+        // Use INTER_AREA for downsampling to avoid moire patterns
+        cv::resize(src_img, dst_img, dst_img.size(), 0, 0, cv::INTER_AREA);
+    }
+
+    int env_id_;                                  // Unique ID for this environment
+    std::string rom_path_;                        // Path to the ROM file
+    std::unique_ptr<ALEInterface> env_;           // ALE interface
+
+    ActionVect action_set_;                       // Available actions
+    int obs_height_;                              // Height to resize frames to for observations
+    int obs_width_;                               // Width to resize frames to for observations
+    int frame_skip_;                              // Number of frames for which to repeat the action
+    bool gray_scale_;                             // Whether to convert frames to grayscale observation or keep RGB
+    bool maxpool_;                                // Whether to maxpool observations
+    int stack_num_;                               // Number of frames to stack for observations
+    int noop_max_;                                // Maximum number of no-ops at reset
+    bool fire_reset_;                             // Whether to press FIRE during reset
+    bool has_fire_action_;                        // Whether FIRE action is available for reset
+    bool episodic_life_;                          // Whether to end episodes when a life is lost
+    int max_episode_steps_;                       // Maximum number of steps per episode before truncating
+
+    int elapsed_step_;                            // Current step in the episode
+    bool game_over_;                               // Whether the game is over
+    int lives_;                                   // Current number of lives
+    float last_reward_;                           // Last reward received
+    int seed_;                                    // Random seed
+    std::mt19937 rng_gen_;                            // Random number generator
+    std::uniform_int_distribution<> noop_generator_;   // Distribution for no-op steps
+
+    Action current_action_;                       // Current action to take
+
+    // Frame buffers
+    std::vector<std::vector<uint8_t>> raw_frames_;  // Raw frame buffers for maxpooling
+    std::vector<uint8_t> resized_frame_;            // Resized frame buffer
+    std::deque<std::vector<uint8_t>> frame_stack_;  // Stack of recent frames
+};
+
+} // namespace vector
+} // namespace ale
+
+#endif // ALE_VECTOR_ATARI_ENV_HPP_

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,11 +8,26 @@
   "features": {
     "sdl": {
       "description": "Enable SDL, this enables display and audio support.",
-      "dependencies": [ "sdl2" ]
+      "dependencies": [
+        "sdl2"
+      ]
+    },
+    "vector": {
+      "description": "Enable Vector, this enables vectorisation of atari environments",
+      "dependencies": [
+        "opencv"
+      ]
     }
   },
-  "builtin-baseline": "9aa0d66373ce3a6868d12353d0d4960db0d4bd18",
+  "builtin-baseline": "1420fe276fe8f6450565e6239a675271c0869359",
   "overrides": [
-    { "name": "sdl2", "version": "2.24.2" }
+    {
+      "name": "sdl2",
+      "version": "2.24.2"
+    },
+    {
+      "name": "opencv",
+      "version": "4.10.0"
+    }
   ]
 }


### PR DESCRIPTION
This PR originated from wishing to use EnvPool; however, the project appeared unsupported. 
Therefore, I initially attempted to copy all the Atari-related code across to minimise the quantity of new code. 
However, the significant differences in the projects (vcpkg vs bazel) and the number of new modules necessary made this more complex than anticipated. 
Then, looking at the EnvPool code, it is very impressive; however, it is intended to support numerous different environments and, as such, uses a large amount of templating and metaprogramming, making maintaining it in ALE very difficult. 

As a result, I took the release of Claude Sonnet 3.7 (don't worry, I have reviewed every line of the LLM-generated code) as a chance to investigate rewriting the EnvPool implementation for ALE, stripping as much of the unnecessary complexity for computation. 

This PR is the product. 
It contains four main components: the sub-environment (`preprocessed_env.hpp`), the vectorizer (`async_vectorizer.hpp`), python bindings (`ale_vector_python_interface.cpp/hpp`) and the python vector environment (`vector_env.py`). To help, `utils.hpp` provides the buffer and intermediate classes. 

The implementation works as follows
* The vectorizer contains a `worker_function` that consistently tries to pass an action to a sub-environment and get the observation back. 
* The sub-environment interfaces with the base ale interface and computes the standard preprocessing (equivalent to `gymnasium.wrappers.AtariPreprocessing`), making it significantly quicker. 
* The bindings and the python implementation provide an easy user interface to access the vectorizer
