### PR TITLE
Add vcpkg build caching to speed up CI

### DIFF
--- a/.github/docker/manylinux-vcpkg.Dockerfile
+++ b/.github/docker/manylinux-vcpkg.Dockerfile
@@ -2,11 +2,11 @@ FROM quay.io/pypa/manylinux2014_x86_64
 
 LABEL org.opencontainers.image.source=https://github.com/Farama-Foundation/Arcade-Learning-Environment
 
-RUN yum install -y curl unzip zip tar
+RUN yum install -y curl unzip zip tar glibc-static
 
+# Install vcpkg
 RUN git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg
-RUN cd /opt/vcpkg && git reset --hard 8150939b6
-
+RUN cd /opt/vcpkg && git reset --hard 9b75e789ece3f942159b8500584e35aafe3979ff
 
 ENV VCPKG_INSTALLATION_ROOT="/opt/vcpkg"
 ENV PATH="${PATH}:/opt/vcpkg"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,10 @@ jobs:
         key: vcpkg-${{ matrix.runners-on }}-${{ matrix.arch }}-${{ hashFiles('vcpkg.json') }}
         restore-keys: vcpkg-${{ matrix.runners-on }}-${{ matrix.arch }}
 
+    - run: ls
+
     - name: Install vcpkg dependencies
-      run: vcpkg install
+      run: vcpkg install --overlay-triplets=cmake/custom-triplets
 
     - run: |
         ls
@@ -134,8 +136,10 @@ jobs:
           push: false
           load: true
 
+      - run: ls
+
       - name: Install vcpkg dependencies
-        run: vcpkg install
+        run: vcpkg install --overlay-triplets=cmake/custom-triplets
 
       - run: |
           ls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
         run: ./scripts/download_unpack_roms.sh
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@v2.23.2
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
           VCPKG_DEFAULT_TRIPLET: "${{ matrix.triplet }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,14 +72,14 @@ jobs:
         restore-keys: vcpkg-${{ matrix.runners-on }}-${{ matrix.arch }}
 
     - run: |
-        ls 
+        ls
         ls vcpkg_installed
 
     - name: Install vcpkg dependencies
       run: vcpkg install
 
     - run: |
-        ls 
+        ls
         ls vcpkg_installed
 
     - name: Download and unpack ROMs
@@ -139,14 +139,14 @@ jobs:
           load: true
 
       - run: |
-          ls 
+          ls
           ls vcpkg_installed
 
       - name: Install vcpkg dependencies
         run: vcpkg install
 
       - run: |
-          ls 
+          ls
           ls vcpkg_installed
 
       - name: Download and unpack ROMs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,24 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
 
+    - name: Cache vcpkg dependencies
+      uses: actions/cache@v4
+      with:
+        path: vcpkg_installed
+        key: vcpkg-${{ matrix.runners-on }}-${{ matrix.arch }}-${{ hashFiles('vcpkg.json') }}
+        restore-keys: vcpkg-${{ matrix.runners-on }}-${{ matrix.arch }}
+
+    - run: |
+        ls 
+        ls vcpkg_installed
+
+    - name: Install vcpkg dependencies
+      run: vcpkg install
+
+    - run: |
+        ls 
+        ls vcpkg_installed
+
     - name: Download and unpack ROMs
       run: ./scripts/download_unpack_roms.sh
 
@@ -96,6 +114,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Cache vcpkg dependencies
+        uses: actions/cache@v4
+        with:
+          path: vcpkg_installed
+          key: vcpkg-${{ matrix.runs-on }}-${{ matrix.arch }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: vcpkg-${{ matrix.runners-on }}-${{ matrix.arch }}
+
       - name: Set up Docker Buildx
         if: runner.os == 'linux'
         id: buildx
@@ -113,6 +138,17 @@ jobs:
           push: false
           load: true
 
+      - run: |
+          ls 
+          ls vcpkg_installed
+
+      - name: Install vcpkg dependencies
+        run: vcpkg install
+
+      - run: |
+          ls 
+          ls vcpkg_installed
+
       - name: Download and unpack ROMs
         run: ./scripts/download_unpack_roms.sh
 
@@ -120,6 +156,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.21.3
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
+          VCPKG_DEFAULT_TRIPLET: "${{ matrix.triplet }}"
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,6 @@ jobs:
         key: vcpkg-${{ matrix.runners-on }}-${{ matrix.arch }}-${{ hashFiles('vcpkg.json') }}
         restore-keys: vcpkg-${{ matrix.runners-on }}-${{ matrix.arch }}
 
-    - run: |
-        ls
-        ls vcpkg_installed
-
     - name: Install vcpkg dependencies
       run: vcpkg install
 
@@ -137,10 +133,6 @@ jobs:
           tags: manylinux-vcpkg:latest
           push: false
           load: true
-
-      - run: |
-          ls
-          ls vcpkg_installed
 
       - name: Install vcpkg dependencies
         run: vcpkg install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,44 +217,44 @@ jobs:
 
           - runs-on: macos-13
             python: '3.9'
-            wheel-name: 'cp39-cp39-macosx_10_15_x86_64'
+            wheel-name: 'cp39-cp39-macosx_13_0_x86_64'
             arch: x86_64
           - runs-on: macos-13
             python: '3.10'
-            wheel-name: 'cp310-cp310-macosx_10_15_x86_64'
+            wheel-name: 'cp310-cp310-macosx_13_0_x86_64'
             arch: x86_64
           - runs-on: macos-13
             python: '3.11'
-            wheel-name: 'cp311-cp311-macosx_10_15_x86_64'
+            wheel-name: 'cp311-cp311-macosx_13_0_x86_64'
             arch: x86_64
           - runs-on: macos-13
             python: '3.12'
-            wheel-name: 'cp312-cp312-macosx_10_15_x86_64'
+            wheel-name: 'cp312-cp312-macosx_13_0_x86_64'
             arch: x86_64
           - runs-on: macos-13
             python: '3.13'
-            wheel-name: 'cp313-cp313-macosx_10_15_x86_64'
+            wheel-name: 'cp313-cp313-macosx_13_0_x86_64'
             arch: x86_64
 
           - runs-on: macos-14
             python: '3.9'
-            wheel-name: 'cp39-cp39-macosx_11_0_arm64'
+            wheel-name: 'cp39-cp39-macosx_13_0_arm64'
             arch: arm64
           - runs-on: macos-14
             python: '3.10'
-            wheel-name: 'cp310-cp310-macosx_11_0_arm64'
+            wheel-name: 'cp310-cp310-macosx_13_0_arm64'
             arch: arm64
           - runs-on: macos-14
             python: '3.11'
-            wheel-name: 'cp311-cp311-macosx_11_0_arm64'
+            wheel-name: 'cp311-cp311-macosx_13_0_arm64'
             arch: arm64
           - runs-on: macos-14
             python: '3.12'
-            wheel-name: 'cp312-cp312-macosx_11_0_arm64'
+            wheel-name: 'cp312-cp312-macosx_13_0_arm64'
             arch: arm64
           - runs-on: macos-14
             python: '3.13'
-            wheel-name: 'cp313-cp313-macosx_11_0_arm64'
+            wheel-name: 'cp313-cp313-macosx_13_0_arm64'
             arch: arm64
 
     runs-on: ${{ matrix.runs-on }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=61",
+    "setuptools>=77.0.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -9,7 +9,8 @@ name = "ale-py"
 description = "The Arcade Learning Environment (ALE) - a platform for AI research."
 readme = "README.md"
 requires-python = ">=3.9"
-license = {text = "GPLv2"}
+license = "GPL-2.0-only"
+license-files = ["LICENSE.md"]
 keywords = ["reinforcement-learning", "arcade-learning-environment", "atari"]
 authors = [
     {name = "Marc G. Bellemare"},
@@ -24,7 +25,6 @@ maintainers = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -72,7 +72,6 @@ norecursedirs = ["vcpkg", "build"]
 skip = ["*-win32", "*i686", "pp*", "*-musllinux*"]
 
 build-frontend = "build"
-
 manylinux-x86_64-image = "manylinux-vcpkg:latest"
 
 [tool.cibuildwheel.linux]
@@ -81,12 +80,12 @@ environment-pass = ["GITHUB_REF"]
 # macOS x86-64
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
-environment = { PIP_ONLY_BINARY = "numpy", VCPKG_DEFAULT_TRIPLET = "x64-osx-mixed", VCPKG_FEATURE_FLAGS = "-compilertracking", MACOSX_DEPLOYMENT_TARGET = "10.15" }
+environment = { PIP_ONLY_BINARY = "numpy", VCPKG_DEFAULT_TRIPLET = "x64-osx-mixed", VCPKG_FEATURE_FLAGS = "-compilertracking", MACOSX_DEPLOYMENT_TARGET = "13.0" }
 
 # macOS arm64
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
-environment = { PIP_ONLY_BINARY = "numpy", VCPKG_DEFAULT_TRIPLET = "arm64-osx-mixed", VCPKG_FEATURE_FLAGS = "-compilertracking", MACOSX_DEPLOYMENT_TARGET = "10.15" }
+environment = { PIP_ONLY_BINARY = "numpy", VCPKG_DEFAULT_TRIPLET = "arm64-osx-mixed", VCPKG_FEATURE_FLAGS = "-compilertracking", MACOSX_DEPLOYMENT_TARGET = "13.0" }
 
 # Windows x64
 [[tool.cibuildwheel.overrides]]

--- a/src/ale/python/__init__.py
+++ b/src/ale/python/__init__.py
@@ -1,8 +1,8 @@
 """Python module for interacting with ALE c++ interface and gymnasium wrapper."""
 
+import importlib.metadata as metadata
 import os
 import platform
-import sys
 import warnings
 
 packagedir = os.path.abspath(os.path.dirname(__file__))
@@ -23,28 +23,13 @@ It can be downloaded from https://aka.ms/vs/16/release/vc_redist.x64.exe."""
         )
 
     # Loading DLLs on Windows is kind of a disaster
-    # The best approach seems to be using LoadLibraryEx
-    # with user defined search paths. This kind of acts like
-    # $ORIGIN or @loader_path on Unix / macOS.
+    # The best approach seems to be using LoadLibraryEx with user defined search paths.
+    # This kind of acts like $ORIGIN or @loader_path on Unix / macOS.
     # This way we guarantee we load OUR DLLs.
-    if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-        os.add_dll_directory(packagedir)
-    else:
-        # TODO: Py38: Remove AddDllDirectory
-        kernel32 = ctypes.WinDLL("kernel32.dll", use_last_error=True)
-        if hasattr(kernel32, "AddDllDirectory"):
-            kernel32.AddDllDirectory(packagedir)
+    os.add_dll_directory(packagedir)
 
-# TODO Py38: Once 3.7 is deprecated use importlib.metadata to parse
-# version string from package.
-try:
-    import importlib.metadata as metadata
-except ImportError:
-    import importlib_metadata as metadata
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    __version__ = "unknown"
+
+__version__ = metadata.version(__package__)
 
 # Import native shared library
 from ale_py._ale_py import (  # noqa: E402

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,11 +8,20 @@
   "features": {
     "sdl": {
       "description": "Enable SDL, this enables display and audio support.",
-      "dependencies": [ "sdl2" ]
+      "dependencies": [
+        {
+          "name": "sdl2",
+          "default-features": false,
+          "features": []
+        }
+      ]
     }
   },
-  "builtin-baseline": "9aa0d66373ce3a6868d12353d0d4960db0d4bd18",
+  "builtin-baseline": "0ca64b4e1c70fa6d9f53b369b8f3f0843797c20c",
   "overrides": [
-    { "name": "sdl2", "version": "2.24.2" }
+    {
+      "name": "sdl2",
+      "version": "2.30.11"
+    }
   ]
 }


### PR DESCRIPTION
For the vector implementation, the build process is longer, therefore, this PR explores if caching the build process would help speed up the CI