### PR TITLE
Fix vector env determinism

### DIFF
--- a/src/ale/vector/preprocessed_env.hpp
+++ b/src/ale/vector/preprocessed_env.hpp
@@ -126,7 +126,7 @@ public:
      * Reset the environment and return the initial observation
      */
     void reset() {
-        if (current_seed_ > 0) {
+        if (current_seed_ >= 0) {
             env_->setInt("random_seed", current_seed_);
             rng_gen_.seed(current_seed_);
 

--- a/tests/python/test_atari_vector_env.py
+++ b/tests/python/test_atari_vector_env.py
@@ -145,6 +145,59 @@ def test_rollout_consistency(
     ale_envs.close()
 
 
+@pytest.mark.parametrize(
+    "num_envs, seeds",
+    [(1, np.array([0])), (3, np.array([1, 2, 3])), (10, np.arange(10))],
+)
+@pytest.mark.parametrize("noop_max", (0, 10, 30))
+@pytest.mark.parametrize("repeat_action_probability", (0, 0.25))
+@pytest.mark.parametrize("use_fire_reset", [False, True])
+def test_determinism(
+    num_envs: int,
+    seeds: np.ndarray,
+    noop_max: int,
+    repeat_action_probability: float,
+    use_fire_reset: bool,
+    game: str = "pong",
+    rollout_length: int = 100,
+):
+    envs_1 = AtariVectorEnv(
+        game,
+        num_envs=num_envs,
+        noop_max=noop_max,
+        repeat_action_probability=repeat_action_probability,
+        use_fire_reset=use_fire_reset,
+    )
+    envs_2 = AtariVectorEnv(
+        game,
+        num_envs=num_envs,
+        noop_max=noop_max,
+        repeat_action_probability=repeat_action_probability,
+        use_fire_reset=use_fire_reset,
+    )
+
+    obs_1, info_1 = envs_1.reset(seed=seeds)
+    obs_2, info_2 = envs_2.reset(seed=seeds)
+
+    assert data_equivalence(obs_1, obs_2)
+    assert data_equivalence(info_1, info_2)
+
+    for i in range(rollout_length):
+        actions = envs_1.action_space.sample()
+
+        obs_1, rewards_1, terminations_1, truncations_1, info_1 = envs_1.step(actions)
+        obs_2, rewards_2, terminations_2, truncations_2, info_2 = envs_1.step(actions)
+
+        assert data_equivalence(obs_1, obs_2)
+        assert data_equivalence(rewards_1, rewards_2)
+        assert data_equivalence(terminations_1, terminations_2)
+        assert data_equivalence(truncations_1, truncations_2)
+        assert data_equivalence(info_1, info_2)
+
+    envs_1.close()
+    envs_2.close()
+
+
 def test_batch_size():
     pass  # TODO
 

--- a/tests/python/test_atari_vector_env.py
+++ b/tests/python/test_atari_vector_env.py
@@ -186,7 +186,7 @@ def test_determinism(
         actions = envs_1.action_space.sample()
 
         obs_1, rewards_1, terminations_1, truncations_1, info_1 = envs_1.step(actions)
-        obs_2, rewards_2, terminations_2, truncations_2, info_2 = envs_1.step(actions)
+        obs_2, rewards_2, terminations_2, truncations_2, info_2 = envs_2.step(actions)
 
         assert data_equivalence(obs_1, obs_2)
         assert data_equivalence(rewards_1, rewards_2)


### PR DESCRIPTION
The `preprocessing_env.hpp` incorrectly doesn't seed the environment if the value is equal to zero. 
This PR fixes the bug and allows the vector environment to be deterministic with tests