### PR TITLE
Fix vector continuous actions implementation

### DIFF
--- a/src/ale/python/ale_vector_xla_interface.cpp
+++ b/src/ale/python/ale_vector_xla_interface.cpp
@@ -24,7 +24,7 @@ ffi::Error XLAResetImpl(
     ffi::ResultBuffer<ffi::S32> episode_frame_numbers_buffer
 ) {
     // Validate handle buffer size
-    if (handle_buffer.element_count() < sizeof(ale::vector::AsyncVectorizer*)) {
+    if (handle_buffer.element_count() == sizeof(ale::vector::AsyncVectorizer*)) {
         return ffi::Error::Internal("Incorrect handle buffer size in reset");
     }
 
@@ -36,7 +36,7 @@ ffi::Error XLAResetImpl(
     }
 
     // Copy handle to output (needed for state management)
-    if (new_handle_buffer->element_count() < handle_buffer.element_count()) {
+    if (new_handle_buffer->element_count() == handle_buffer.element_count()) {
         return ffi::Error::Internal("Incorrect new handle buffer size in reset");
     }
     std::memcpy(new_handle_buffer->typed_data(),
@@ -58,10 +58,20 @@ ffi::Error XLAResetImpl(
         // Receive the observations after reset
         auto timesteps = vectorizer->recv();
 
-        // Copy data to output buffers
+        if (timesteps.empty()) {
+            return ffi::Error::Internal("No timesteps received after step");
+        } else if (timesteps.size() != vectorizer->get_batch_size()) {
+            return ffi::Error::Internal("Number of timesteps is wrong");
+        }
+
         size_t obs_size = vectorizer->get_obs_size();
-        size_t num_envs = timesteps.size();
-        for (size_t i = 0; i < num_envs; ++i) {
+
+        // Check if the observations buffer is large enough
+        if (observations_buffer->element_count() == vectorizer->get_batch_size() * obs_size) {
+            return ffi::Error::Internal("Observations buffer too small");
+        }
+
+        for (size_t i = 0; i < vectorizer->get_batch_size(); ++i) {
             const auto& timestep = timesteps[i];
 
             std::memcpy(
@@ -118,7 +128,7 @@ ffi::Error XLAStepImpl(
     ffi::ResultBuffer<ffi::S32> episode_frame_numbers_buffer
 ) {
     // Validate handle buffer size
-    if (handle_buffer.element_count() < sizeof(ale::vector::AsyncVectorizer*)) {
+    if (handle_buffer.element_count() == sizeof(ale::vector::AsyncVectorizer*)) {
         return ffi::Error::Internal("Incorrect handle buffer size in step");
     }
 
@@ -130,7 +140,7 @@ ffi::Error XLAStepImpl(
     }
 
     // Copy handle to output
-    if (new_handle_buffer->element_count() < handle_buffer.element_count()) {
+    if (new_handle_buffer->element_count() == handle_buffer.element_count()) {
         return ffi::Error::Internal("New handle buffer too small in step");
     }
     std::memcpy(new_handle_buffer->typed_data(),
@@ -139,11 +149,10 @@ ffi::Error XLAStepImpl(
 
     try {
         size_t num_envs = vectorizer->get_batch_size();
-        size_t obs_size = vectorizer->get_obs_size();
 
-        if (action_id_buffer.element_count() < num_envs) {
+        if (action_id_buffer.element_count() == num_envs) {
             return ffi::Error::Internal("Action id buffer is too small");
-        } else if (paddle_strength_buffer.element_count() < num_envs) {
+        } else if (paddle_strength_buffer.element_count() == num_envs) {
             return ffi::Error::Internal("Paddle strength buffer is too small");
         }
 
@@ -156,14 +165,24 @@ ffi::Error XLAStepImpl(
 
         // Step the environments
         vectorizer->send(actions);
+
+        // Receive the timesteps
         auto timesteps = vectorizer->recv();
 
-        if (observations_buffer->element_count() < timesteps.size() * obs_size) {
-            return ffi::Error::Internal("Observations buffer too small in step");
+        if (timesteps.empty()) {
+            return ffi::Error::Internal("No timesteps received after step");
+        } else if (timesteps.size() != vectorizer->get_batch_size()) {
+            return ffi::Error::Internal("Number of timesteps is wrong");
         }
 
-        // Copy data to output buffers
-        for (size_t i = 0; i < timesteps.size(); ++i) {
+        size_t obs_size = vectorizer->get_obs_size();
+
+        // Check if the observations buffer is large enough
+        if (observations_buffer->element_count() == vectorizer->get_batch_size() * obs_size) {
+            return ffi::Error::Internal("Observations buffer is too small");
+        }
+
+        for (size_t i = 0; i < vectorizer->get_batch_size(); ++i) {
             const auto& timestep = timesteps[i];
 
             std::memcpy(

--- a/src/ale/python/ale_vector_xla_interface.cpp
+++ b/src/ale/python/ale_vector_xla_interface.cpp
@@ -24,7 +24,7 @@ ffi::Error XLAResetImpl(
     ffi::ResultBuffer<ffi::S32> episode_frame_numbers_buffer
 ) {
     // Validate handle buffer size
-    if (handle_buffer.element_count() == sizeof(ale::vector::AsyncVectorizer*)) {
+    if (handle_buffer.element_count() < sizeof(ale::vector::AsyncVectorizer*)) {
         return ffi::Error::Internal("Incorrect handle buffer size in reset");
     }
 
@@ -36,7 +36,7 @@ ffi::Error XLAResetImpl(
     }
 
     // Copy handle to output (needed for state management)
-    if (new_handle_buffer->element_count() == handle_buffer.element_count()) {
+    if (new_handle_buffer->element_count() < handle_buffer.element_count()) {
         return ffi::Error::Internal("Incorrect new handle buffer size in reset");
     }
     std::memcpy(new_handle_buffer->typed_data(),
@@ -58,20 +58,10 @@ ffi::Error XLAResetImpl(
         // Receive the observations after reset
         auto timesteps = vectorizer->recv();
 
-        if (timesteps.empty()) {
-            return ffi::Error::Internal("No timesteps received after step");
-        } else if (timesteps.size() != vectorizer->get_batch_size()) {
-            return ffi::Error::Internal("Number of timesteps is wrong");
-        }
-
+        // Copy data to output buffers
         size_t obs_size = vectorizer->get_obs_size();
-
-        // Check if the observations buffer is large enough
-        if (observations_buffer->element_count() == vectorizer->get_batch_size() * obs_size) {
-            return ffi::Error::Internal("Observations buffer too small");
-        }
-
-        for (size_t i = 0; i < vectorizer->get_batch_size(); ++i) {
+        size_t num_envs = timesteps.size();
+        for (size_t i = 0; i < num_envs; ++i) {
             const auto& timestep = timesteps[i];
 
             std::memcpy(
@@ -128,7 +118,7 @@ ffi::Error XLAStepImpl(
     ffi::ResultBuffer<ffi::S32> episode_frame_numbers_buffer
 ) {
     // Validate handle buffer size
-    if (handle_buffer.element_count() == sizeof(ale::vector::AsyncVectorizer*)) {
+    if (handle_buffer.element_count() < sizeof(ale::vector::AsyncVectorizer*)) {
         return ffi::Error::Internal("Incorrect handle buffer size in step");
     }
 
@@ -140,7 +130,7 @@ ffi::Error XLAStepImpl(
     }
 
     // Copy handle to output
-    if (new_handle_buffer->element_count() == handle_buffer.element_count()) {
+    if (new_handle_buffer->element_count() < handle_buffer.element_count()) {
         return ffi::Error::Internal("New handle buffer too small in step");
     }
     std::memcpy(new_handle_buffer->typed_data(),
@@ -149,10 +139,11 @@ ffi::Error XLAStepImpl(
 
     try {
         size_t num_envs = vectorizer->get_batch_size();
+        size_t obs_size = vectorizer->get_obs_size();
 
-        if (action_id_buffer.element_count() == num_envs) {
+        if (action_id_buffer.element_count() < num_envs) {
             return ffi::Error::Internal("Action id buffer is too small");
-        } else if (paddle_strength_buffer.element_count() == num_envs) {
+        } else if (paddle_strength_buffer.element_count() < num_envs) {
             return ffi::Error::Internal("Paddle strength buffer is too small");
         }
 
@@ -165,24 +156,14 @@ ffi::Error XLAStepImpl(
 
         // Step the environments
         vectorizer->send(actions);
-
-        // Receive the timesteps
         auto timesteps = vectorizer->recv();
 
-        if (timesteps.empty()) {
-            return ffi::Error::Internal("No timesteps received after step");
-        } else if (timesteps.size() != vectorizer->get_batch_size()) {
-            return ffi::Error::Internal("Number of timesteps is wrong");
+        if (observations_buffer->element_count() < timesteps.size() * obs_size) {
+            return ffi::Error::Internal("Observations buffer too small in step");
         }
 
-        size_t obs_size = vectorizer->get_obs_size();
-
-        // Check if the observations buffer is large enough
-        if (observations_buffer->element_count() == vectorizer->get_batch_size() * obs_size) {
-            return ffi::Error::Internal("Observations buffer is too small");
-        }
-
-        for (size_t i = 0; i < vectorizer->get_batch_size(); ++i) {
+        // Copy data to output buffers
+        for (size_t i = 0; i < timesteps.size(); ++i) {
             const auto& timestep = timesteps[i];
 
             std::memcpy(

--- a/src/ale/python/env.py
+++ b/src/ale/python/env.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import sys
 from functools import lru_cache
 from typing import Any, Literal
-from warnings import warn
 
 import ale_py
 import gymnasium
@@ -165,28 +164,22 @@ class AtariEnv(gymnasium.Env, utils.EzPickle):
         self.load_game()
 
         # get the set of legal actions
-        if continuous and not full_action_space:
-            warn(
-                "`continuous` is set to `True`, but `full_action_space` is set to `False`. "
-                "This will error out when the continuous actions are discretized to illegal action spaces. "
-                "Therefore, `full_action_space` has been automatically set to `True`."
-            )
-        self._action_set = (
-            self.ale.getLegalActionSet()
-            if (full_action_space or continuous)
-            else self.ale.getMinimalActionSet()
-        )
+        if full_action_space or continuous:
+            self._action_set = self.ale.getLegalActionSet()
+        else:
+            self._action_set = self.ale.getMinimalActionSet()
 
         # action space
         self.continuous = continuous
         self.continuous_action_threshold = continuous_action_threshold
         if continuous:
-            # Actions are radius, theta, and fire, where first two are the
-            # parameters of polar coordinates.
+            # Actions are radius, theta, and fire, where first two are the parameters of polar coordinates.
             self.action_space = spaces.Box(
-                np.array([0.0, -np.pi, 0.0]).astype(np.float32),
-                np.array([1.0, np.pi, 1.0]).astype(np.float32),
-            )  # radius, theta, fire. First two are polar coordinates.
+                low=np.array([0.0, -np.pi, 0.0]).astype(np.float32),
+                high=np.array([1.0, np.pi, 1.0]).astype(np.float32),
+                dtype=np.float32,
+                shape=(3,),
+            )
         else:
             self.action_space = spaces.Discrete(len(self._action_set))
 

--- a/src/ale/python/env.py
+++ b/src/ale/python/env.py
@@ -276,10 +276,11 @@ class AtariEnv(gymnasium.Env, utils.EzPickle):
         else:
             raise error.Error(f"Invalid frameskip type: {self._frameskip}")
 
-        # action formatting
         if self.continuous:
             # compute the x, y, fire of the joystick
             assert isinstance(action, np.ndarray)
+            assert action.dtype == np.float32
+            assert action.shape == (3,)
             x, y = action[0] * np.cos(action[1]), action[0] * np.sin(action[1])
             action_idx = self.map_action_idx(
                 left_center_right=(

--- a/src/ale/python/vector_env.py
+++ b/src/ale/python/vector_env.py
@@ -84,7 +84,7 @@ class AtariVectorEnv(VectorEnv):
             reward_clipping=reward_clipping,
             max_episode_steps=max_num_frames_per_episode,
             repeat_action_probability=repeat_action_probability,
-            full_action_space=full_action_space,
+            full_action_space=full_action_space or continuous,
             batch_size=batch_size,
             num_threads=num_threads,
             thread_affinity_offset=thread_affinity_offset,

--- a/src/ale/python/vector_env.py
+++ b/src/ale/python/vector_env.py
@@ -139,7 +139,7 @@ class AtariVectorEnv(VectorEnv):
             reset_indices = np.arange(self.num_envs)
         else:
             reset_mask = options["reset_mask"]
-            assert isinstance(reset_mask, np.ndarray) and reset_mask.dtype == np.bool
+            assert isinstance(reset_mask, np.ndarray) and reset_mask.dtype == np.bool_
             reset_indices, _ = np.where(reset_mask)
 
         if seed is None:
@@ -167,8 +167,8 @@ class AtariVectorEnv(VectorEnv):
             assert actions.dtype == np.float32
             assert actions.shape == (self.batch_size, 2)
 
-            x = actions[0, :] * np.cos(actions[1, :])
-            y = actions[0, :] * np.sin(actions[1, :])
+            x = actions[:, 0] * np.cos(actions[:, 1])
+            y = actions[:, 0] * np.sin(actions[:, 1])
 
             horizontal = -(x < self.continuous_action_threshold) + (
                 x > self.continuous_action_threshold
@@ -176,10 +176,10 @@ class AtariVectorEnv(VectorEnv):
             vertical = -(y < self.continuous_action_threshold) + (
                 y > self.continuous_action_threshold
             )
-            fire = actions[1, :] > self.continuous_action_threshold
+            fire = actions[:, 1] > self.continuous_action_threshold
 
             action_ids = self.map_action_idx[np.array([horizontal, vertical, fire])]
-            paddle_strength = actions[1, :]
+            paddle_strength = actions[:, 1]
             self.ale.send(action_ids, paddle_strength)
         else:
             assert isinstance(actions, np.ndarray)
@@ -241,7 +241,7 @@ class AtariVectorEnv(VectorEnv):
 
             if reset_mask is not None:
                 assert (
-                    isinstance(reset_mask, np.ndarray) and reset_mask.dtype == np.bool
+                    isinstance(reset_mask, np.ndarray) and reset_mask.dtype == np.bool_
                 )
                 reset_indices, _ = np.where(reset_mask)
             else:
@@ -274,8 +274,8 @@ class AtariVectorEnv(VectorEnv):
                 assert actions.dtype == np.float32
                 assert actions.shape == (self.batch_size, 2)
 
-                x = actions[0, :] * np.cos(actions[1, :])
-                y = actions[0, :] * np.sin(actions[1, :])
+                x = actions[:, 0] * np.cos(actions[:, 1])
+                y = actions[:, 0] * np.sin(actions[:, 1])
 
                 horizontal = -(x < self.continuous_action_threshold) + (
                     x > self.continuous_action_threshold
@@ -283,10 +283,10 @@ class AtariVectorEnv(VectorEnv):
                 vertical = -(y < self.continuous_action_threshold) + (
                     y > self.continuous_action_threshold
                 )
-                fire = actions[1, :] > self.continuous_action_threshold
+                fire = actions[:, 1] > self.continuous_action_threshold
 
                 action_ids = self.map_action_idx[np.array([horizontal, vertical, fire])]
-                paddle_strength = actions[1, :]
+                paddle_strength = actions[:, 1]
             else:
                 assert isinstance(actions, np.ndarray)
                 assert actions.dtype == np.int64 or actions.dtype == np.int32
@@ -296,8 +296,8 @@ class AtariVectorEnv(VectorEnv):
                 paddle_strength = np.ones(self.batch_size)
 
             xla_call = jax.ffi.ffi_call(
-                "atari_vector_xla_step",
-                (
+                target_name="atari_vector_xla_step",
+                result_shape_dtypes=(
                     jax.ShapeDtypeStruct((8,), jnp.uint8),  # handle
                     jax.ShapeDtypeStruct(
                         self.observation_space.shape, jnp.uint8

--- a/src/ale/python/vector_env.py
+++ b/src/ale/python/vector_env.py
@@ -105,6 +105,8 @@ class AtariVectorEnv(VectorEnv):
             self.single_action_space = Box(
                 low=np.array([0.0, -np.pi, 0.0]).astype(np.float32),
                 high=np.array([1.0, np.pi, 1.0]).astype(np.float32),
+                dtype=np.float32,
+                shape=(3,),
             )
         else:
             self.single_action_space = Discrete(len(self.ale.get_action_set()))
@@ -165,7 +167,7 @@ class AtariVectorEnv(VectorEnv):
         if self.continuous:
             assert isinstance(actions, np.ndarray)
             assert actions.dtype == np.float32
-            assert actions.shape == (self.batch_size, 2)
+            assert actions.shape == (self.batch_size, 3)
 
             x = actions[:, 0] * np.cos(actions[:, 1])
             y = actions[:, 0] * np.sin(actions[:, 1])
@@ -176,10 +178,10 @@ class AtariVectorEnv(VectorEnv):
             vertical = -(y < self.continuous_action_threshold) + (
                 y > self.continuous_action_threshold
             )
-            fire = actions[:, 1] > self.continuous_action_threshold
+            fire = actions[:, 2] > self.continuous_action_threshold
 
             action_ids = self.map_action_idx[np.array([horizontal, vertical, fire])]
-            paddle_strength = actions[:, 1]
+            paddle_strength = actions[:, 0]
             self.ale.send(action_ids, paddle_strength)
         else:
             assert isinstance(actions, np.ndarray)

--- a/src/ale/vector/preprocessed_env.hpp
+++ b/src/ale/vector/preprocessed_env.hpp
@@ -195,7 +195,10 @@ namespace ale::vector {
             game_over_ = false;
 
             const int action_id = current_action_.action_id;
-            const Action action = (action_id < 0 || action_id >= static_cast<int>(action_set_.size())) ? PLAYER_A_NOOP : action_set_[action_id];
+            if (action_id < 0 || action_id >= action_set_.size()) {
+                throw std::out_of_range("Stepping sub-environment with action_id: " + std::to_string(action_id) + ", however, this is either less than zero or greater than available actions (" + std::to_string(action_set_.size()) + ")");
+            }
+            const Action action = action_set_[action_id];
             const float strength = current_action_.paddle_strength;
 
             // Execute action for frame_skip frames

--- a/tests/python/test_atari_vector_env.py
+++ b/tests/python/test_atari_vector_env.py
@@ -154,14 +154,18 @@ def test_obs_params__equivalence(stack_num, img_height, img_width, frame_skip):
     assert_rollout_equivalence(gym_envs, ale_envs)
 
 
-def test_continuous_actions_equivalence():
+def test_continuous_actions():
     gym_envs = gym.vector.SyncVectorEnv(
         [
             lambda: gym.wrappers.FrameStackObservation(
                 gym.wrappers.AtariPreprocessing(
-                    gym.make("BreakoutNoFrameskip-v4", continuous=True),
+                    gym.make(
+                        "BreakoutNoFrameskip-v4",
+                        continuous=True,
+                    ),
                     noop_max=0,
                 ),
+                stack_size=4,
                 padding_type="zero",
             )
             for _ in range(NUM_ENVS)

--- a/tests/python/test_atari_vector_env.py
+++ b/tests/python/test_atari_vector_env.py
@@ -56,47 +56,23 @@ def test_reset_step_shapes(num_envs, stack_num, img_height, img_width):
     envs.close()
 
 
-@pytest.mark.parametrize("num_envs", [1, 8])
-@pytest.mark.parametrize("stack_num", [4, 6])
-@pytest.mark.parametrize("img_height, img_width", [(84, 84), (210, 160)])
-@pytest.mark.parametrize("frame_skip", [1, 4])
-def test_rollout_consistency(
-    num_envs, stack_num, img_height, img_width, frame_skip, rollout_length=100
+NUM_ENVS = 8
+
+
+def assert_rollout_equivalence(
+    gym_envs,
+    ale_envs,
+    rollout_length=100,
+    reset_seed=123,
+    action_seed=123,
 ):
     """Test if both environments produce similar results over a short rollout."""
-    gym_envs = gym.vector.SyncVectorEnv(
-        [
-            lambda: gym.wrappers.FrameStackObservation(
-                gym.wrappers.AtariPreprocessing(
-                    gym.make("BreakoutNoFrameskip-v4"),
-                    noop_max=0,
-                    frame_skip=frame_skip,
-                    screen_size=(img_width, img_height),
-                ),
-                stack_size=stack_num,
-                padding_type="zero",
-            )
-            for _ in range(num_envs)
-        ],
-    )
-    ale_envs = AtariVectorEnv(
-        game="breakout",
-        num_envs=num_envs,
-        frameskip=frame_skip,
-        img_height=img_height,
-        img_width=img_width,
-        stack_num=stack_num,
-        noop_max=0,
-        use_fire_reset=False,
-        maxpool=frame_skip > 1,
-    )
-
     assert gym_envs.num_envs == ale_envs.num_envs
     assert gym_envs.observation_space == ale_envs.observation_space
     assert gym_envs.action_space == ale_envs.action_space
 
-    gym_obs, gym_info = gym_envs.reset(seed=123)
-    ale_obs, ale_info = ale_envs.reset(seed=123)
+    gym_obs, gym_info = gym_envs.reset(seed=reset_seed)
+    ale_obs, ale_info = ale_envs.reset(seed=reset_seed)
 
     assert data_equivalence(gym_obs, ale_obs)
 
@@ -106,10 +82,10 @@ def test_rollout_consistency(
         if not key.startswith("_") and key != "seeds"
     }
     env_ids = ale_info.pop("env_id")
-    assert np.all(env_ids == np.arange(num_envs))
+    assert np.all(env_ids == np.arange(gym_envs.num_envs))
     assert data_equivalence(gym_info, ale_info)
 
-    ale_envs.action_space.seed(123)
+    ale_envs.action_space.seed(action_seed)
     for i in range(rollout_length):
         actions = ale_envs.action_space.sample()
 
@@ -124,8 +100,7 @@ def test_rollout_consistency(
             # For MacOS ARM, there is a known problem where there is a max difference of 1 for 1 or 2 pixels
             diff = gym_obs.astype(np.int32) - ale_obs.astype(np.int32)
             gym.logger.warn(
-                f"rollout error for timestep={i}, max diff={np.max(diff)}, min diff={np.min(diff)}, non-zero count={np.count_nonzero(diff)} "
-                f"({num_envs=}, {stack_num=}, {img_height=}, {img_width=}, {frame_skip=})"
+                f"rollout obs diff for timestep={i}, max diff={np.max(diff)}, min diff={np.min(diff)}, non-zero count={np.count_nonzero(diff)}"
             )
 
         assert data_equivalence(gym_rewards.astype(np.int32), ale_rewards)
@@ -138,11 +113,69 @@ def test_rollout_consistency(
             if not key.startswith("_") and key != "seeds"
         }
         env_ids = ale_info.pop("env_id")
-        assert np.all(env_ids == np.arange(num_envs))
+        assert np.all(env_ids == np.arange(gym_envs.num_envs))
         assert data_equivalence(gym_info, ale_info)
 
     gym_envs.close()
     ale_envs.close()
+
+
+@pytest.mark.parametrize("stack_num", [4, 6])
+@pytest.mark.parametrize("img_height, img_width", [(84, 84), (210, 160)])
+@pytest.mark.parametrize("frame_skip", [1, 4])
+def test_obs_params__equivalence(stack_num, img_height, img_width, frame_skip):
+    gym_envs = gym.vector.SyncVectorEnv(
+        [
+            lambda: gym.wrappers.FrameStackObservation(
+                gym.wrappers.AtariPreprocessing(
+                    gym.make("BreakoutNoFrameskip-v4"),
+                    noop_max=0,
+                    frame_skip=frame_skip,
+                    screen_size=(img_width, img_height),
+                ),
+                stack_size=stack_num,
+                padding_type="zero",
+            )
+            for _ in range(NUM_ENVS)
+        ],
+    )
+    ale_envs = AtariVectorEnv(
+        game="breakout",
+        num_envs=NUM_ENVS,
+        frameskip=frame_skip,
+        img_height=img_height,
+        img_width=img_width,
+        stack_num=stack_num,
+        noop_max=0,
+        use_fire_reset=False,
+        maxpool=frame_skip > 1,
+    )
+
+    assert_rollout_equivalence(gym_envs, ale_envs)
+
+
+def test_continuous_actions_equivalence():
+    gym_envs = gym.vector.SyncVectorEnv(
+        [
+            lambda: gym.wrappers.FrameStackObservation(
+                gym.wrappers.AtariPreprocessing(
+                    gym.make("BreakoutNoFrameskip-v4", continuous=True),
+                    noop_max=0,
+                ),
+                padding_type="zero",
+            )
+            for _ in range(NUM_ENVS)
+        ],
+    )
+    ale_envs = AtariVectorEnv(
+        game="breakout",
+        num_envs=NUM_ENVS,
+        noop_max=0,
+        use_fire_reset=False,
+        continuous=True,
+    )
+
+    assert_rollout_equivalence(gym_envs, ale_envs)
 
 
 @pytest.mark.parametrize(
@@ -198,19 +231,7 @@ def test_determinism(
     envs_2.close()
 
 
-def test_continuous_action_space():
-    pass  # TODO
-
-
 def test_batch_size_async():
-    pass  # TODO
-
-
-def test_full_action_space():
-    pass  # TODO
-
-
-def test_max_episode_steps():
     pass  # TODO
 
 

--- a/tests/python/test_atari_vector_env.py
+++ b/tests/python/test_atari_vector_env.py
@@ -135,7 +135,9 @@ def assert_rollout_equivalence(
 @pytest.mark.parametrize("img_height, img_width", [(84, 84), (210, 160)])
 @pytest.mark.parametrize("frame_skip", [1, 4])
 @pytest.mark.parametrize("grayscale", [False, True])
-def test_obs_params_equivalence(stack_num, img_height, img_width, frame_skip, grayscale, num_envs=8):
+def test_obs_params_equivalence(
+    stack_num, img_height, img_width, frame_skip, grayscale, num_envs=8
+):
     gym_envs = gym.vector.SyncVectorEnv(
         [
             lambda: gym.wrappers.FrameStackObservation(
@@ -174,7 +176,11 @@ def test_continuous_equivalence(continuous_action_threshold, num_envs=8):
         [
             lambda: gym.wrappers.FrameStackObservation(
                 gym.wrappers.AtariPreprocessing(
-                    gym.make("BreakoutNoFrameskip-v4", continuous=True, continuous_action_threshold=continuous_action_threshold),
+                    gym.make(
+                        "BreakoutNoFrameskip-v4",
+                        continuous=True,
+                        continuous_action_threshold=continuous_action_threshold,
+                    ),
                     noop_max=0,
                 ),
                 stack_size=4,
@@ -189,7 +195,7 @@ def test_continuous_equivalence(continuous_action_threshold, num_envs=8):
         noop_max=0,
         use_fire_reset=False,
         continuous=True,
-        continuous_action_threshold=continuous_action_threshold
+        continuous_action_threshold=continuous_action_threshold,
     )
 
     assert_rollout_equivalence(gym_envs, ale_envs)

--- a/tests/python/test_atari_vector_env.py
+++ b/tests/python/test_atari_vector_env.py
@@ -108,7 +108,7 @@ def assert_rollout_equivalence(
             assert gym_obs.dtype == ale_obs.dtype
             assert np.max(diff) <= 2
             assert np.min(diff) >= -2
-            assert count <= 3
+            assert count <= 5
 
             gym.logger.warn(
                 f"rollout obs diff for timestep={i}, max diff={np.max(diff)}, min diff={np.min(diff)}, non-zero count={count}"


### PR DESCRIPTION
The `AtariVectorEnv` continuous action implementation was horribly wrong and wasn't noticed as there wasn't tests. 
This PR fixes the implementation and adds tests for it