### PR TITLE
Change `get_keys_to_action` from `dict[ale_py.Action, tuple[int, ...]` to `dict[str, tuple[int, ...]]`

### DIFF
--- a/src/ale/python/env.py
+++ b/src/ale/python/env.py
@@ -352,7 +352,7 @@ class AtariEnv(gymnasium.Env, utils.EzPickle):
         }
 
     @lru_cache(1)
-    def get_keys_to_action(self) -> dict[tuple[int, ...], ale_py.Action]:
+    def get_keys_to_action(self) -> dict[tuple[str, ...], int]:
         """Return keymapping -> actions for human play.
 
         Up, down, left and right are wasd keys with fire being space.
@@ -361,12 +361,12 @@ class AtariEnv(gymnasium.Env, utils.EzPickle):
         Returns:
             Dictionary of key values to actions
         """
-        UP = ord("w")
-        LEFT = ord("a")
-        RIGHT = ord("d")
-        DOWN = ord("s")
-        FIRE = ord(" ")
-        NOOP = ord("e")
+        UP = "w"
+        LEFT = "a"
+        RIGHT = "d"
+        DOWN = "s"
+        FIRE = " "
+        NOOP = "e"
 
         mapping = {
             ale_py.Action.NOOP: (NOOP,),
@@ -394,7 +394,8 @@ class AtariEnv(gymnasium.Env, utils.EzPickle):
         # where action_idx is the integer value of the action enum
         #
         return {
-            tuple(sorted(mapping[act_idx])): act_idx for act_idx in self._action_set
+            tuple(sorted(mapping[act_idx])): act_idx.value
+            for act_idx in self._action_set
         }
 
     @staticmethod

--- a/src/ale/python/env.py
+++ b/src/ale/python/env.py
@@ -352,7 +352,7 @@ class AtariEnv(gymnasium.Env, utils.EzPickle):
         }
 
     @lru_cache(1)
-    def get_keys_to_action(self) -> dict[tuple[str, ...], int]:
+    def get_keys_to_action(self) -> dict[tuple[str, ...], int | np.ndarray]:
         """Return keymapping -> actions for human play.
 
         Up, down, left and right are wasd keys with fire being space.
@@ -390,13 +390,13 @@ class AtariEnv(gymnasium.Env, utils.EzPickle):
         }
 
         # Map
-        #   (key, key, ...) -> action_idx
-        # where action_idx is the integer value of the action enum
-        #
-        return {
-            tuple(sorted(mapping[act_idx])): act_idx.value
-            for act_idx in self._action_set
-        }
+        #   (key, key, ...) -> action
+        if self.continuous:
+            raise AttributeError(
+                "`get_keys_to_action` can't be provided for this Atari environment as `continuous=True`."
+            )
+        else:
+            return {mapping[action]: i for i, action in enumerate(self._action_set)}
 
     @staticmethod
     @lru_cache(18)

--- a/tests/python/test_atari_env.py
+++ b/tests/python/test_atari_env.py
@@ -147,31 +147,22 @@ def test_gym_img_rgb_obs(tetris_env):
     assert obs.shape[-1] == 3
 
 
-@pytest.mark.parametrize("tetris_env", [{"full_action_space": True}], indirect=True)
-def test_gym_keys_to_action(tetris_env):
-    keys_full_action_space = {
-        (101,): 0,
-        (32,): 1,
-        (119,): 2,
-        (100,): 3,
-        (97,): 4,
-        (115,): 5,
-        (100, 119): 6,
-        (97, 119): 7,
-        (100, 115): 8,
-        (97, 115): 9,
-        (32, 119): 10,
-        (32, 100): 11,
-        (32, 97): 12,
-        (32, 115): 13,
-        (32, 100, 119): 14,
-        (32, 97, 119): 15,
-        (32, 100, 115): 16,
-        (32, 97, 115): 17,
-    }
-    keys_to_actions = tetris_env.unwrapped.get_keys_to_action()
+def test_gym_keys_to_action():
+    env = gymnasium.make("ALE/MsPacman-v5").unwrapped
+    assert len(env._action_set) == len(env.get_keys_to_action())
+    for keys, action in env.get_keys_to_action().items():
+        assert isinstance(keys, tuple)
+        assert all(isinstance(key, str) for key in keys)
+        assert action in env.action_space
+    env.close()
 
-    assert keys_full_action_space == keys_to_actions
+    env = gymnasium.make("ALE/MsPacman-v5", continuous=True).unwrapped
+    with pytest.raises(
+        AttributeError,
+        match="`get_keys_to_action` can't be provided for this Atari environment as `continuous=True`.",
+    ):
+        env.get_keys_to_action()
+    env.close()
 
 
 @pytest.mark.parametrize("tetris_env", [{"full_action_space": True}], indirect=True)
@@ -288,21 +279,3 @@ def test_sound_obs():
         check_env(env.unwrapped, skip_render_check=True)
 
     assert caught_warnings == [], [caught.message.args[0] for caught in caught_warnings]
-
-
-def test_get_keys_to_action():
-    env = gymnasium.make("ALE/MsPacman-v5").unwrapped
-    assert len(env._action_set) == len(env.get_keys_to_action())
-    for keys, action in env.get_keys_to_action().items():
-        assert isinstance(keys, tuple)
-        assert all(isinstance(key, str) for key in keys)
-        assert action in env.action_space
-    env.close()
-
-    env = gymnasium.make("ALE/MsPacman-v5", continuous=True).unwrapped
-    with pytest.raises(
-        AttributeError,
-        match="`get_keys_to_action` can't be provided for this Atari environment as `continuous=True`.",
-    ):
-        env.get_keys_to_action()
-    env.close()

--- a/tests/python/test_atari_env.py
+++ b/tests/python/test_atari_env.py
@@ -288,3 +288,15 @@ def test_sound_obs():
         check_env(env.unwrapped, skip_render_check=True)
 
     assert caught_warnings == [], [caught.message.args[0] for caught in caught_warnings]
+
+
+def test_get_keys_to_action():
+    env = gymnasium.make("ALE/MsPacman-v5").unwrapped
+    assert len(env._action_set) == len(env.get_keys_to_action())
+    for keys, action in env.get_keys_to_action():
+        assert isinstance(keys, tuple)
+        assert all(isinstance(key, str) for key in keys)
+        assert action in env.action_space
+
+    env = gymnasium.make("ALE/MsPacman-v5", continuous=True).unwrapped
+    assert len(env._action_set) == len(env.get_keys_to_action())

--- a/tests/python/test_atari_env.py
+++ b/tests/python/test_atari_env.py
@@ -293,10 +293,16 @@ def test_sound_obs():
 def test_get_keys_to_action():
     env = gymnasium.make("ALE/MsPacman-v5").unwrapped
     assert len(env._action_set) == len(env.get_keys_to_action())
-    for keys, action in env.get_keys_to_action():
+    for keys, action in env.get_keys_to_action().items():
         assert isinstance(keys, tuple)
         assert all(isinstance(key, str) for key in keys)
         assert action in env.action_space
+    env.close()
 
     env = gymnasium.make("ALE/MsPacman-v5", continuous=True).unwrapped
-    assert len(env._action_set) == len(env.get_keys_to_action())
+    with pytest.raises(
+        AttributeError,
+        match="`get_keys_to_action` can't be provided for this Atari environment as `continuous=True`.",
+    ):
+        env.get_keys_to_action()
+    env.close()


### PR DESCRIPTION
https://github.com/Farama-Foundation/Gymnasium/pull/1384

AtariEnv implements the `get_keys_to_action` with the wrong types
This PR updates it to use a strings for keys to make it easier to debug and int for actions