### PR TITLE
Replace pybind11 with nanobind

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=77.0.0",
+    "nanobind==2.7",
     "jax >= 0.4.31; python_version > '3.9' and (sys_platform == 'win32' or sys_platform == 'linux')"
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ norecursedirs = ["vcpkg", "build"]
 skip = ["*-win32", "*i686", "pp*", "*-musllinux*"]
 
 build-frontend = "build"
+environment = "PYTHON_EXECUTABLE=$(python -c 'import sys; print(sys.executable)')"
 manylinux-x86_64-image = "manylinux-vcpkg:latest"
 
 [tool.cibuildwheel.linux]

--- a/src/ale/python/CMakeLists.txt
+++ b/src/ale/python/CMakeLists.txt
@@ -1,8 +1,9 @@
-find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
 
 execute_process(
-  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  COMMAND "${Python3_EXECUTABLE}" -m nanobind --cmake_dir
   OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
+message(STATUS "nanobind root: ${nanobind_ROOT}")
 find_package(nanobind CONFIG REQUIRED)
 
 # If vector library is enabled, include the vector Python interface

--- a/src/ale/python/CMakeLists.txt
+++ b/src/ale/python/CMakeLists.txt
@@ -1,18 +1,18 @@
-find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+find_package(Python COMPONENTS Interpreter Development REQUIRED)
 
 execute_process(
-  COMMAND "${Python3_EXECUTABLE}" -m nanobind --cmake_dir
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
   OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
 find_package(nanobind CONFIG REQUIRED)
 
 # If vector library is enabled, include the vector Python interface
 # XLA Integration
 if (BUILD_VECTOR_LIB AND BUILD_VECTOR_XLA_LIB)
-#    message(STATUS "Python Executable: '${Python3_EXECUTABLE}'")
-#    message(STATUS "Python3_SITELIB=${Python3_SITELIB}, Python3_SITEARCH=${Python3_SITEARCH}")
+#    message(STATUS "Python Executable: '${Python_EXECUTABLE}'")
+#    message(STATUS "Python3_SITELIB=${Python_SITELIB}, Python3_SITEARCH=${Python_SITEARCH}")
     execute_process(
-        COMMAND "${Python3_EXECUTABLE}" "-c"
-        "import sys; sys.path.append(r'${Python3_SITELIB}'); sys.path.append(r'${Python3_SITEARCH}'); from jax import ffi; print(ffi.include_dir())"
+        COMMAND "${Python_EXECUTABLE}" "-c"
+        "import sys; sys.path.append(r'${Python_SITELIB}'); sys.path.append(r'${Python_SITEARCH}'); from jax import ffi; print(ffi.include_dir())"
         OUTPUT_STRIP_TRAILING_WHITESPACE
         OUTPUT_VARIABLE XLA_DIR
     )

--- a/src/ale/python/CMakeLists.txt
+++ b/src/ale/python/CMakeLists.txt
@@ -1,7 +1,8 @@
-find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
+set(Python_EXECUTABLE ${PYTHON_EXECUTABLE})
+find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
 
 execute_process(
-  COMMAND "${Python3_EXECUTABLE}" -m nanobind --cmake_dir
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
   OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
 message(STATUS "nanobind root: ${nanobind_ROOT}")
 find_package(nanobind CONFIG REQUIRED)

--- a/src/ale/python/CMakeLists.txt
+++ b/src/ale/python/CMakeLists.txt
@@ -1,16 +1,9 @@
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 
-include(FetchContent)
-set(NANOBIND_VER 2.7.0)
-find_package(nanobind ${NANOBIND_VER} QUIET)
-
-if(NOT nanobind_FOUND)
-    FetchContent_Declare(
-        nanobind
-        GIT_REPOSITORY https://github.com/wjakob/nanobind
-        GIT_TAG v${NANOBIND_VER})
-    FetchContent_MakeAvailable(nanobind)
-endif()
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
+find_package(nanobind CONFIG REQUIRED)
 
 # If vector library is enabled, include the vector Python interface
 # XLA Integration

--- a/src/ale/python/CMakeLists.txt
+++ b/src/ale/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Python COMPONENTS Interpreter Development REQUIRED)
+find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
 
 execute_process(
   COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir

--- a/src/ale/python/CMakeLists.txt
+++ b/src/ale/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
+find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 
 include(FetchContent)
 set(NANOBIND_VER 2.7.0)

--- a/src/ale/python/CMakeLists.txt
+++ b/src/ale/python/CMakeLists.txt
@@ -1,16 +1,15 @@
 find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
 
 include(FetchContent)
-set(PYBIND11_FINDPYTHON ON)
-set(PYBIND11_VER 2.13.1)
-find_package(pybind11 ${PYBIND11_VER} QUIET)
+set(NANOBIND_VER 2.7.0)
+find_package(nanobind ${NANOBIND_VER} QUIET)
 
-if(NOT pybind11_FOUND)
+if(NOT nanobind_FOUND)
     FetchContent_Declare(
-        pybind11
-        GIT_REPOSITORY https://github.com/pybind/pybind11
-        GIT_TAG v${PYBIND11_VER})
-    FetchContent_MakeAvailable(pybind11)
+        nanobind
+        GIT_REPOSITORY https://github.com/wjakob/nanobind
+        GIT_TAG v${NANOBIND_VER})
+    FetchContent_MakeAvailable(nanobind)
 endif()
 
 # If vector library is enabled, include the vector Python interface
@@ -28,28 +27,23 @@ if (BUILD_VECTOR_LIB AND BUILD_VECTOR_XLA_LIB)
 
 #    find_package(CUDAToolkit REQUIRED)
 
-    add_library(ale-py MODULE ale_python_interface.cpp ale_vector_python_interface.cpp ale_vector_xla_interface.cpp)
+    nanobind_add_module(ale-py ale_python_interface.cpp ale_vector_python_interface.cpp ale_vector_xla_interface.cpp)
     set_target_properties(ale-py PROPERTIES POSITION_INDEPENDENT_CODE ON CUDA_STANDARD 17)
     target_include_directories(ale-py PUBLIC ${XLA_DIR})
     target_compile_definitions(ale-py PRIVATE BUILD_VECTOR_LIB BUILD_VECTOR_XLA_LIB)
 
 elseif (BUILD_VECTOR_LIB)
-    add_library(ale-py MODULE ale_python_interface.cpp ale_vector_python_interface.cpp)
+    nanobind_add_module(ale-py ale_python_interface.cpp ale_vector_python_interface.cpp)
     target_compile_definitions(ale-py PRIVATE BUILD_VECTOR_LIB)
 else ()
-    add_library(ale-py MODULE ale_python_interface.cpp)
+    nanobind_add_module(ale-py ale_python_interface.cpp)
 endif()
 
-# Depend on the ALE and pybind11 module
+# Depend on the ALE library
 target_link_libraries(ale-py PUBLIC ale ale-lib)
-target_link_libraries(ale-py PRIVATE pybind11::module)
 
 # The native module is imported as _ale_py
-# Make sure to set the proper prefix and extension from pybind11
-set_target_properties(ale-py PROPERTIES
-    OUTPUT_NAME _ale_py
-    PREFIX "${PYTHON_MODULE_PREFIX}"
-    SUFFIX "${PYTHON_MODULE_EXTENSION}")
+set_target_properties(ale-py PROPERTIES OUTPUT_NAME _ale_py)
 
 # To test ale-py we need to make sure that all generated resources
 # are in CMAKE_CURRENT_BINARY_DIR, i.e., build/src/python.

--- a/src/ale/python/CMakeLists.txt
+++ b/src/ale/python/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 
 execute_process(
-  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  COMMAND "${Python3_EXECUTABLE}" -m nanobind --cmake_dir
   OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
 find_package(nanobind CONFIG REQUIRED)
 

--- a/src/ale/python/ale_python_interface.cpp
+++ b/src/ale/python/ale_python_interface.cpp
@@ -19,7 +19,8 @@
 namespace ale {
 
 void ALEPythonInterface::getScreen(
-    nb::ndarray<nb::numpy, pixel_t, nb::c_contig> buffer) {
+    nb::ndarray<nb::numpy, pixel_t, nb::shape<nb::any, nb::any>, nb::c_contig>& buffer) {
+
   if (buffer.ndim() != 2) {
     throw std::runtime_error("Expected a numpy array with two dimensions.");
   }
@@ -37,11 +38,12 @@ void ALEPythonInterface::getScreen(
   pixel_t* src = environment->getScreen().getArray();
   pixel_t* dst = buffer.data();
 
-  std::copy(src, src + (w * h * sizeof(pixel_t)), dst);
+  std::copy(src, src + (w * h), dst);
 }
 
 void ALEPythonInterface::getScreenRGB(
-    nb::ndarray<nb::numpy, pixel_t, nb::c_contig> buffer) {
+    nb::ndarray<nb::numpy, pixel_t, nb::shape<nb::any, nb::any, 3>, nb::c_contig>& buffer) {
+
   if (buffer.ndim() != 3) {
     throw std::runtime_error("Expected a numpy array with three dimensions.");
   }
@@ -63,7 +65,8 @@ void ALEPythonInterface::getScreenRGB(
 }
 
 void ALEPythonInterface::getScreenGrayscale(
-    nb::ndarray<nb::numpy, pixel_t, nb::c_contig> buffer) {
+    nb::ndarray<nb::numpy, pixel_t, nb::shape<nb::any, nb::any>, nb::c_contig>& buffer) {
+
   if (buffer.ndim() != 2) {
     throw std::runtime_error("Expected a numpy array with two dimensions.");
   }
@@ -84,72 +87,65 @@ void ALEPythonInterface::getScreenGrayscale(
   theOSystem->colourPalette().applyPaletteGrayscale(dst, src, h * w);
 }
 
-nb::ndarray<nb::numpy, pixel_t> ALEPythonInterface::getScreen() {
+nb::ndarray<nb::numpy, pixel_t, nb::shape<nb::any, nb::any>, nb::c_contig> ALEPythonInterface::getScreen() {
   int32_t w = environment->getScreen().width();
   int32_t h = environment->getScreen().height();
 
-  // Create new array with shape {h, w}
-  size_t shape[2] = {static_cast<size_t>(h), static_cast<size_t>(w)};
-  auto buffer = nb::steal(nb::detail::ndarray_new(
-      nb::handle(nb::dtype<pixel_t>().raw_dtype()),
-      2, shape, nb::handle(nullptr), nullptr, nb::dtype<pixel_t>()));
+  // Create ndarray
+  auto buffer = nb::ndarray<nb::numpy, pixel_t, nb::shape<nb::any, nb::any>, nb::c_contig>(
+      nullptr, {h, w});
 
   // Call our overloaded getScreen function
-  this->getScreen(nb::cast<nb::ndarray<nb::numpy, pixel_t, nb::c_contig>>(buffer));
+  this->getScreen(buffer);
 
-  return nb::cast<nb::ndarray<nb::numpy, pixel_t>>(buffer);
+  return buffer;
 }
 
-nb::ndarray<nb::numpy, pixel_t> ALEPythonInterface::getScreenRGB() {
+nb::ndarray<nb::numpy, pixel_t, nb::shape<nb::any, nb::any, 3>, nb::c_contig> ALEPythonInterface::getScreenRGB() {
   int32_t h = environment->getScreen().height();
   int32_t w = environment->getScreen().width();
 
-  // Create new array with shape {h, w, 3}
-  size_t shape[3] = {static_cast<size_t>(h), static_cast<size_t>(w), 3};
-  auto buffer = nb::steal(nb::detail::ndarray_new(
-      nb::handle(nb::dtype<pixel_t>().raw_dtype()),
-      3, shape, nb::handle(nullptr), nullptr, nb::dtype<pixel_t>()));
+  // Create ndarray
+  auto buffer = nb::ndarray<nb::numpy, pixel_t, nb::shape<nb::any, nb::any, 3>, nb::c_contig>(
+      nullptr, {h, w, 3});
 
   // Call our overloaded getScreenRGB function
-  this->getScreenRGB(nb::cast<nb::ndarray<nb::numpy, pixel_t, nb::c_contig>>(buffer));
+  this->getScreenRGB(buffer);
 
-  return nb::cast<nb::ndarray<nb::numpy, pixel_t>>(buffer);
+  return buffer;
 }
 
-nb::ndarray<nb::numpy, pixel_t>
+nb::ndarray<nb::numpy, pixel_t, nb::shape<nb::any, nb::any>, nb::c_contig>
 ALEPythonInterface::getScreenGrayscale() {
   int32_t w = environment->getScreen().width();
   int32_t h = environment->getScreen().height();
 
-  // Create new array with shape {h, w}
-  size_t shape[2] = {static_cast<size_t>(h), static_cast<size_t>(w)};
-  auto buffer = nb::steal(nb::detail::ndarray_new(
-      nb::handle(nb::dtype<pixel_t>().raw_dtype()),
-      2, shape, nb::handle(nullptr), nullptr, nb::dtype<pixel_t>()));
+  // Create ndarray
+  auto buffer = nb::ndarray<nb::numpy, pixel_t, nb::shape<nb::any, nb::any>, nb::c_contig>(
+      nullptr, {h, w});
 
   // Call our overloaded getScreenGrayscale function
-  this->getScreenGrayscale(nb::cast<nb::ndarray<nb::numpy, pixel_t, nb::c_contig>>(buffer));
+  this->getScreenGrayscale(buffer);
 
-  return nb::cast<nb::ndarray<nb::numpy, pixel_t>>(buffer);
+  return buffer;
 }
 
-nb::ndarray<nb::numpy, uint8_t> ALEPythonInterface::getAudio() {
+const nb::ndarray<nb::numpy, uint8_t, nb::shape<nb::any>, nb::c_contig> ALEPythonInterface::getAudio() {
   const std::vector<uint8_t> &audio = ALEInterface::getAudio();
 
-  // Create new array and copy data
-  size_t shape[1] = {audio.size()};
-  auto buffer = nb::steal(nb::detail::ndarray_new(
-      nb::handle(nb::dtype<uint8_t>().raw_dtype()),
-      1, shape, nb::handle(nullptr), nullptr, nb::dtype<uint8_t>()));
+  // Create ndarray from data
+  auto buffer = nb::ndarray<nb::numpy, uint8_t, nb::shape<nb::any>, nb::c_contig>(
+      nullptr, {audio.size()});
 
-  auto array = nb::cast<nb::ndarray<nb::numpy, uint8_t, nb::c_contig>>(buffer);
-  std::copy(audio.data(), audio.data() + audio.size(), array.data());
+  // Copy data
+  std::copy(audio.data(), audio.data() + audio.size(), buffer.data());
 
-  return nb::cast<nb::ndarray<nb::numpy, uint8_t>>(buffer);
+  return buffer;
 }
 
 void ALEPythonInterface::getAudio(
-    nb::ndarray<nb::numpy, uint8_t, nb::c_contig> buffer) {
+    nb::ndarray<nb::numpy, uint8_t, nb::shape<nb::any>, nb::c_contig>& buffer) {
+
   if (buffer.ndim() != 1) {
     throw std::runtime_error("Expected a numpy array with one dimension.");
   }
@@ -168,23 +164,21 @@ void ALEPythonInterface::getAudio(
   std::copy(audio.data(), audio.data() + audio.size(), dst);
 }
 
-nb::ndarray<nb::numpy, uint8_t> ALEPythonInterface::getRAM() {
+const nb::ndarray<nb::numpy, uint8_t, nb::shape<nb::any>, nb::c_contig> ALEPythonInterface::getRAM() {
   const ALERAM& ram = ALEInterface::getRAM();
 
-  // Create new array and copy data
-  size_t shape[1] = {static_cast<size_t>(ram.size())};
-  auto buffer = nb::steal(nb::detail::ndarray_new(
-      nb::handle(nb::dtype<uint8_t>().raw_dtype()),
-      1, shape, nb::handle(nullptr), nullptr, nb::dtype<uint8_t>()));
+  // Create ndarray from data
+  auto buffer = nb::ndarray<nb::numpy, uint8_t, nb::shape<nb::any>, nb::c_contig>(
+      nullptr, {ram.size()});
 
-  auto array = nb::cast<nb::ndarray<nb::numpy, uint8_t, nb::c_contig>>(buffer);
-  std::copy(ram.array(), ram.array() + ram.size(), array.data());
+  // Copy data
+  std::copy(ram.array(), ram.array() + ram.size(), buffer.data());
 
-  return nb::cast<nb::ndarray<nb::numpy, uint8_t>>(buffer);
+  return buffer;
 }
 
 void ALEPythonInterface::getRAM(
-    nb::ndarray<nb::numpy, uint8_t, nb::c_contig> buffer) {
+    nb::ndarray<nb::numpy, uint8_t, nb::shape<nb::any>, nb::c_contig>& buffer) {
   const ALERAM& ram = ALEInterface::getRAM();
 
   if (buffer.ndim() != 1) {

--- a/src/ale/python/ale_python_interface.hpp
+++ b/src/ale/python/ale_python_interface.hpp
@@ -18,10 +18,12 @@
 
 #include <optional>
 
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/stl/filesystem.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/filesystem.h>
 
 #include "ale/ale_interface.hpp"
 #include "version.hpp"
@@ -34,11 +36,11 @@
 #endif
 
 
-namespace py = pybind11;
-void init_vector_module(py::module &m);
-void init_vector_module_xla(py::module &m);
+namespace nb = nanobind;
+void init_vector_module(nb::module_ &m);
+void init_vector_module_xla(nb::module_ &m);
 
-using namespace py::literals;
+using namespace nb::literals;
 
 namespace ale {
 
@@ -46,26 +48,26 @@ class ALEPythonInterface : public ALEInterface {
     public:
         using ALEInterface::ALEInterface;
 
-        void getScreen(py::array_t<pixel_t, py::array::c_style>& buffer);
-        void getScreenRGB(py::array_t<pixel_t, py::array::c_style>& buffer);
-        void getScreenGrayscale(py::array_t<pixel_t, py::array::c_style>& buffer);
+        void getScreen(nb::ndarray<nb::numpy, pixel_t, nb::c_contig> buffer);
+        void getScreenRGB(nb::ndarray<nb::numpy, pixel_t, nb::c_contig> buffer);
+        void getScreenGrayscale(nb::ndarray<nb::numpy, pixel_t, nb::c_contig> buffer);
 
-        py::array_t<pixel_t, py::array::c_style> getScreen();
-        py::array_t<pixel_t, py::array::c_style> getScreenRGB();
-        py::array_t<pixel_t, py::array::c_style> getScreenGrayscale();
+        nb::ndarray<nb::numpy, pixel_t> getScreen();
+        nb::ndarray<nb::numpy, pixel_t> getScreenRGB();
+        nb::ndarray<nb::numpy, pixel_t> getScreenGrayscale();
 
         inline reward_t act(unsigned int action, const float paddle_strength = 1.0) {
             return ALEInterface::act(static_cast<Action>(action), paddle_strength);
         }
 
-        inline py::tuple getScreenDims() const {
+        inline nb::tuple getScreenDims() const {
             const ALEScreen& screen = ALEInterface::getScreen();
-            return py::make_tuple(screen.height(), screen.width());
+            return nb::make_tuple(screen.height(), screen.width());
         }
 
         inline uint32_t getAudioSize() const { return ALEInterface::getAudio().size(); }
-        const py::array_t<uint8_t, py::array::c_style> getAudio();
-        void getAudio(py::array_t<uint8_t, py::array::c_style> &buffer);
+        nb::ndarray<nb::numpy, uint8_t> getAudio();
+        void getAudio(nb::ndarray<nb::numpy, uint8_t, nb::c_contig> buffer);
 
         // Implicitly cast std::string -> fs::path
         inline void loadROM(const std::string &rom_file) {
@@ -78,21 +80,21 @@ class ALEPythonInterface : public ALEInterface {
         }
 
         inline uint32_t getRAMSize() { return ALEInterface::getRAM().size(); }
-        const py::array_t<uint8_t, py::array::c_style> getRAM();
-        void getRAM(py::array_t<uint8_t, py::array::c_style>& buffer);
+        nb::ndarray<nb::numpy, uint8_t> getRAM();
+        void getRAM(nb::ndarray<nb::numpy, uint8_t, nb::c_contig> buffer);
 };
 
 } // namespace ale
 
-PYBIND11_MODULE(_ale_py, m) {
-    m.attr("__version__") = py::str(ALE_VERSION);
+NB_MODULE(_ale_py, m) {
+    m.attr("__version__") = ALE_VERSION;
 #ifdef ALE_SDL_SUPPORT
-    m.attr("SDL_SUPPORT") = py::bool_(true);
+    m.attr("SDL_SUPPORT") = true;
 #else
-    m.attr("SDL_SUPPORT") = py::bool_(false);
+    m.attr("SDL_SUPPORT") = false;
 #endif
 
-    py::enum_<ale::Action>(m, "Action")
+    nb::enum_<ale::Action>(m, "Action")
         .value("NOOP", ale::PLAYER_A_NOOP)
         .value("FIRE", ale::PLAYER_A_FIRE)
         .value("UP", ale::PLAYER_A_UP)
@@ -113,16 +115,16 @@ PYBIND11_MODULE(_ale_py, m) {
         .value("DOWNLEFTFIRE", ale::PLAYER_A_DOWNLEFTFIRE)
         .export_values();
 
-    py::enum_<ale::Logger::mode>(m, "LoggerMode")
+    nb::enum_<ale::Logger::mode>(m, "LoggerMode")
         .value("Info", ale::Logger::mode::Info)
         .value("Warning", ale::Logger::mode::Warning)
         .value("Error", ale::Logger::mode::Error)
         .export_values();
 
-    py::class_<ale::ALEState>(m, "ALEState")
-        .def(py::init<>())
-        .def(py::init<const ale::ALEState&, const std::string&>())
-        .def(py::init<const std::string&>())
+    nb::class_<ale::ALEState>(m, "ALEState")
+        .def(nb::init<>())
+        .def(nb::init<const ale::ALEState&, const std::string&>())
+        .def(nb::init<const std::string&>())
         .def("equals", &ale::ALEState::equals)
         .def("getFrameNumber", &ale::ALEState::getFrameNumber)
         .def("getEpisodeFrameNumber", &ale::ALEState::getEpisodeFrameNumber)
@@ -130,20 +132,16 @@ PYBIND11_MODULE(_ale_py, m) {
         .def("getCurrentMode", &ale::ALEState::getCurrentMode)
         .def("serialize", &ale::ALEState::serialize)
         .def("__eq__", &ale::ALEState::equals)
-        .def(py::pickle(
-            [](ale::ALEState& a) {
-                return py::make_tuple(py::bytes(a.serialize()));
-            },
-            [](const py::tuple &t) {
-                if (t.size() != 1)
-                    throw std::runtime_error("Invalid ALEState state...");
+        .def("__getstate__", [](const ale::ALEState& a) {
+            return nb::bytes(a.serialize().data(), a.serialize().size());
+        })
+        .def("__setstate__", [](ale::ALEState& a, nb::bytes state) {
+            std::string state_str(static_cast<const char*>(state.data()), state.size());
+            a = ale::ALEState(state_str);
+        });
 
-                ale::ALEState state(t[0].cast<std::string>());
-                return state;
-            }));
-
-    py::class_<ale::ALEPythonInterface>(m, "ALEInterface")
-        .def(py::init<>())
+    nb::class_<ale::ALEPythonInterface>(m, "ALEInterface")
+        .def(nb::init<>())
         .def("getString", &ale::ALEPythonInterface::getString)
         .def("getInt", &ale::ALEPythonInterface::getInt)
         .def("getBool", &ale::ALEPythonInterface::getBool)
@@ -157,11 +155,11 @@ PYBIND11_MODULE(_ale_py, m) {
         .def_static("isSupportedROM", &ale::ALEPythonInterface::isSupportedROM)
         .def_static("isSupportedROM", &ale::ALEInterface::isSupportedROM)
         .def("act", &ale::ALEPythonInterface::act,
-            py::arg("action"), py::arg("paddle_strength") = 1.0)
+            "action"_a, "paddle_strength"_a = 1.0)
         .def("act", &ale::ALEInterface::act,
-            py::arg("action"), py::arg("paddle_strength") = 1.0)
+            "action"_a, "paddle_strength"_a = 1.0)
         .def("game_over", &ale::ALEPythonInterface::game_over,
-            py::kw_only(), py::arg("with_truncation") = py::bool_(true))
+            "with_truncation"_a = true)
         .def("game_truncated", &ale::ALEPythonInterface::game_truncated)
         .def("reset_game", &ale::ALEPythonInterface::reset_game)
         .def("getAvailableModes", &ale::ALEPythonInterface::getAvailableModes)
@@ -173,21 +171,21 @@ PYBIND11_MODULE(_ale_py, m) {
         .def("getFrameNumber", &ale::ALEPythonInterface::getFrameNumber)
         .def("lives", &ale::ALEPythonInterface::lives)
         .def("getEpisodeFrameNumber", &ale::ALEPythonInterface::getEpisodeFrameNumber)
-        .def("getScreen", static_cast<void (ale::ALEPythonInterface::*)(py::array_t<ale::pixel_t, py::array::c_style> &)>(&ale::ALEPythonInterface::getScreen))
-        .def("getScreen", static_cast<py::array_t<ale::pixel_t, py::array::c_style>(ale::ALEPythonInterface::*)()>(&ale::ALEPythonInterface::getScreen))
-        .def("getScreenRGB", static_cast<void (ale::ALEPythonInterface::*)(py::array_t<ale::pixel_t, py::array::c_style> &)>(&ale::ALEPythonInterface::getScreenRGB))
-        .def("getScreenRGB", static_cast<py::array_t<ale::pixel_t, py::array::c_style>(ale::ALEPythonInterface::*)()>(&ale::ALEPythonInterface::getScreenRGB))
-        .def("getScreenGrayscale", static_cast<void (ale::ALEPythonInterface::*)(py::array_t<ale::pixel_t, py::array::c_style> &)>(&ale::ALEPythonInterface::getScreenGrayscale))
-        .def("getScreenGrayscale", static_cast<py::array_t<ale::pixel_t, py::array::c_style>(ale::ALEPythonInterface::*)()>(&ale::ALEPythonInterface::getScreenGrayscale))
+        .def("getScreen", static_cast<void (ale::ALEPythonInterface::*)(nb::ndarray<nb::numpy, ale::pixel_t, nb::c_contig>)>(&ale::ALEPythonInterface::getScreen))
+        .def("getScreen", static_cast<nb::ndarray<nb::numpy, ale::pixel_t>(ale::ALEPythonInterface::*)()>(&ale::ALEPythonInterface::getScreen))
+        .def("getScreenRGB", static_cast<void (ale::ALEPythonInterface::*)(nb::ndarray<nb::numpy, ale::pixel_t, nb::c_contig>)>(&ale::ALEPythonInterface::getScreenRGB))
+        .def("getScreenRGB", static_cast<nb::ndarray<nb::numpy, ale::pixel_t>(ale::ALEPythonInterface::*)()>(&ale::ALEPythonInterface::getScreenRGB))
+        .def("getScreenGrayscale", static_cast<void (ale::ALEPythonInterface::*)(nb::ndarray<nb::numpy, ale::pixel_t, nb::c_contig>)>(&ale::ALEPythonInterface::getScreenGrayscale))
+        .def("getScreenGrayscale", static_cast<nb::ndarray<nb::numpy, ale::pixel_t>(ale::ALEPythonInterface::*)()>(&ale::ALEPythonInterface::getScreenGrayscale))
         .def("getScreenDims", &ale::ALEPythonInterface::getScreenDims)
         .def("getAudioSize", &ale::ALEPythonInterface::getAudioSize)
-        .def("getAudio", static_cast<const py::array_t<uint8_t, py::array::c_style> (ale::ALEPythonInterface::*)()>(&ale::ALEPythonInterface::getAudio))
-        .def("getAudio", static_cast<void (ale::ALEPythonInterface::*)(py::array_t<uint8_t, py::array::c_style> &)>(&ale::ALEPythonInterface::getAudio))
+        .def("getAudio", static_cast<nb::ndarray<nb::numpy, uint8_t> (ale::ALEPythonInterface::*)()>(&ale::ALEPythonInterface::getAudio))
+        .def("getAudio", static_cast<void (ale::ALEPythonInterface::*)(nb::ndarray<nb::numpy, uint8_t, nb::c_contig>)>(&ale::ALEPythonInterface::getAudio))
         .def("getRAMSize", &ale::ALEPythonInterface::getRAMSize)
-        .def("getRAM", static_cast<const py::array_t<uint8_t, py::array::c_style> (ale::ALEPythonInterface::*)()>(&ale::ALEPythonInterface::getRAM))
-        .def("getRAM", static_cast<void (ale::ALEPythonInterface::*)(py::array_t<uint8_t, py::array::c_style> &)>(&ale::ALEPythonInterface::getRAM))
+        .def("getRAM", static_cast<nb::ndarray<nb::numpy, uint8_t> (ale::ALEPythonInterface::*)()>(&ale::ALEPythonInterface::getRAM))
+        .def("getRAM", static_cast<void (ale::ALEPythonInterface::*)(nb::ndarray<nb::numpy, uint8_t, nb::c_contig>)>(&ale::ALEPythonInterface::getRAM))
         .def("setRAM", &ale::ALEPythonInterface::setRAM)
-        .def("cloneState", &ale::ALEPythonInterface::cloneState, py::kw_only(), py::arg("include_rng") = py::bool_(false))
+        .def("cloneState", &ale::ALEPythonInterface::cloneState, "include_rng"_a = false)
         .def("restoreState", &ale::ALEPythonInterface::restoreState)
         .def("cloneSystemState", &ale::ALEPythonInterface::cloneSystemState)
         .def("restoreSystemState", &ale::ALEPythonInterface::restoreSystemState)

--- a/src/ale/python/ale_vector_python_interface.cpp
+++ b/src/ale/python/ale_vector_python_interface.cpp
@@ -1,12 +1,8 @@
 #include "ale_vector_python_interface.hpp"
-
 #include <nanobind/nanobind.h>
-#include <nanobind/stl/vector.h>
-#include <nanobind/stl/string.h>
-#include <nanobind/stl/filesystem.h>
-#include <nanobind/stl/tuple.h>
 #include <nanobind/ndarray.h>
-
+#include <nanobind/stl/vector.h>
+#include <nanobind/stl/filesystem.h>
 #include <vector>
 #include <cmath>
 #include <tuple>
@@ -49,45 +45,31 @@ void init_vector_module(nb::module_& m) {
             int stack_num = std::get<0>(obs_shape);
             int height = std::get<1>(obs_shape);
             int width = std::get<2>(obs_shape);
-            int channels = self.is_grayscale() ? 1 : 3;
 
             // Create a single NumPy array for all observations
             nb::ndarray<nb::numpy, uint8_t> observations;
             if (self.is_grayscale()) {
-                size_t shape[4] = {static_cast<size_t>(num_envs), static_cast<size_t>(stack_num), static_cast<size_t>(height), static_cast<size_t>(width)};
-                observations = nb::steal(nb::detail::ndarray_new(
-                    nb::handle(nb::dtype<uint8_t>().raw_dtype()),
-                    4, shape, nb::handle(nullptr), nullptr, nb::dtype<uint8_t>()));
+                observations = nb::ndarray<nb::numpy, uint8_t>(
+                    nullptr, {num_envs, stack_num, height, width});
             } else {
-                size_t shape[5] = {static_cast<size_t>(num_envs), static_cast<size_t>(stack_num), static_cast<size_t>(height), static_cast<size_t>(width), 3};
-                observations = nb::steal(nb::detail::ndarray_new(
-                    nb::handle(nb::dtype<uint8_t>().raw_dtype()),
-                    5, shape, nb::handle(nullptr), nullptr, nb::dtype<uint8_t>()));
+                observations = nb::ndarray<nb::numpy, uint8_t>(
+                    nullptr, {num_envs, stack_num, height, width, 3});
             }
             auto observations_ptr = observations.data();
 
             // Create arrays for info fields
-            size_t env_shape[1] = {static_cast<size_t>(num_envs)};
+            auto env_ids = nb::ndarray<nb::numpy, int>(nullptr, {num_envs});
+            auto lives = nb::ndarray<nb::numpy, int>(nullptr, {num_envs});
+            auto frame_numbers = nb::ndarray<nb::numpy, int>(nullptr, {num_envs});
+            auto episode_frame_numbers = nb::ndarray<nb::numpy, int>(nullptr, {num_envs});
 
-            auto env_ids = nb::steal(nb::detail::ndarray_new(
-                nb::handle(nb::dtype<int>().raw_dtype()),
-                1, env_shape, nb::handle(nullptr), nullptr, nb::dtype<int>()));
-            auto lives = nb::steal(nb::detail::ndarray_new(
-                nb::handle(nb::dtype<int>().raw_dtype()),
-                1, env_shape, nb::handle(nullptr), nullptr, nb::dtype<int>()));
-            auto frame_numbers = nb::steal(nb::detail::ndarray_new(
-                nb::handle(nb::dtype<int>().raw_dtype()),
-                1, env_shape, nb::handle(nullptr), nullptr, nb::dtype<int>()));
-            auto episode_frame_numbers = nb::steal(nb::detail::ndarray_new(
-                nb::handle(nb::dtype<int>().raw_dtype()),
-                1, env_shape, nb::handle(nullptr), nullptr, nb::dtype<int>()));
-
-            auto env_ids_array = nb::cast<nb::ndarray<nb::numpy, int>>(env_ids);
-            auto lives_array = nb::cast<nb::ndarray<nb::numpy, int>>(lives);
-            auto frame_numbers_array = nb::cast<nb::ndarray<nb::numpy, int>>(frame_numbers);
-            auto episode_frame_numbers_array = nb::cast<nb::ndarray<nb::numpy, int>>(episode_frame_numbers);
+            auto env_ids_ptr = env_ids.data();
+            auto lives_ptr = lives.data();
+            auto frame_numbers_ptr = frame_numbers.data();
+            auto episode_frame_numbers_ptr = episode_frame_numbers.data();
 
             // Copy data from observations to NumPy arrays
+            int channels = self.is_grayscale() ? 1 : 3;
             size_t obs_size = stack_num * height * width * channels;
             for (int i = 0; i < num_envs; i++) {
                 const auto& timestep = timesteps[i];
@@ -100,10 +82,10 @@ void init_vector_module(nb::module_& m) {
                 );
 
                 // Copy info fields
-                env_ids_array.data()[i] = timestep.env_id;
-                lives_array.data()[i] = timestep.lives;
-                frame_numbers_array.data()[i] = timestep.frame_number;
-                episode_frame_numbers_array.data()[i] = timestep.episode_frame_number;
+                env_ids_ptr[i] = timestep.env_id;
+                lives_ptr[i] = timestep.lives;
+                frame_numbers_ptr[i] = timestep.frame_number;
+                episode_frame_numbers_ptr[i] = timestep.episode_frame_number;
             }
 
             // Create info dict
@@ -128,59 +110,38 @@ void init_vector_module(nb::module_& m) {
             int stack_num = std::get<0>(shape_info);
             int height = std::get<1>(shape_info);
             int width = std::get<2>(shape_info);
-            int channels = self.is_grayscale() ? 1 : 3;
 
             // Create NumPy arrays
             nb::ndarray<nb::numpy, uint8_t> observations;
             if (self.is_grayscale()) {
-                size_t shape[4] = {static_cast<size_t>(num_envs), static_cast<size_t>(stack_num), static_cast<size_t>(height), static_cast<size_t>(width)};
-                observations = nb::steal(nb::detail::ndarray_new(
-                    nb::handle(nb::dtype<uint8_t>().raw_dtype()),
-                    4, shape, nb::handle(nullptr), nullptr, nb::dtype<uint8_t>()));
+                observations = nb::ndarray<nb::numpy, uint8_t>(
+                    nullptr, {num_envs, stack_num, height, width});
             } else {
-                size_t shape[5] = {static_cast<size_t>(num_envs), static_cast<size_t>(stack_num), static_cast<size_t>(height), static_cast<size_t>(width), 3};
-                observations = nb::steal(nb::detail::ndarray_new(
-                    nb::handle(nb::dtype<uint8_t>().raw_dtype()),
-                    5, shape, nb::handle(nullptr), nullptr, nb::dtype<uint8_t>()));
+                observations = nb::ndarray<nb::numpy, uint8_t>(
+                    nullptr, {num_envs, stack_num, height, width, 3});
             }
 
-            size_t env_shape[1] = {static_cast<size_t>(num_envs)};
+            auto rewards = nb::ndarray<nb::numpy, int>(nullptr, {num_envs});
+            auto terminations = nb::ndarray<nb::numpy, bool>(nullptr, {num_envs});
+            auto truncations = nb::ndarray<nb::numpy, bool>(nullptr, {num_envs});
+            auto env_ids = nb::ndarray<nb::numpy, int>(nullptr, {num_envs});
+            auto lives = nb::ndarray<nb::numpy, int>(nullptr, {num_envs});
+            auto frame_numbers = nb::ndarray<nb::numpy, int>(nullptr, {num_envs});
+            auto episode_frame_numbers = nb::ndarray<nb::numpy, int>(nullptr, {num_envs});
 
-            auto rewards = nb::steal(nb::detail::ndarray_new(
-                nb::handle(nb::dtype<int>().raw_dtype()),
-                1, env_shape, nb::handle(nullptr), nullptr, nb::dtype<int>()));
-            auto terminations = nb::steal(nb::detail::ndarray_new(
-                nb::handle(nb::dtype<bool>().raw_dtype()),
-                1, env_shape, nb::handle(nullptr), nullptr, nb::dtype<bool>()));
-            auto truncations = nb::steal(nb::detail::ndarray_new(
-                nb::handle(nb::dtype<bool>().raw_dtype()),
-                1, env_shape, nb::handle(nullptr), nullptr, nb::dtype<bool>()));
-            auto env_ids = nb::steal(nb::detail::ndarray_new(
-                nb::handle(nb::dtype<int>().raw_dtype()),
-                1, env_shape, nb::handle(nullptr), nullptr, nb::dtype<int>()));
-            auto lives = nb::steal(nb::detail::ndarray_new(
-                nb::handle(nb::dtype<int>().raw_dtype()),
-                1, env_shape, nb::handle(nullptr), nullptr, nb::dtype<int>()));
-            auto frame_numbers = nb::steal(nb::detail::ndarray_new(
-                nb::handle(nb::dtype<int>().raw_dtype()),
-                1, env_shape, nb::handle(nullptr), nullptr, nb::dtype<int>()));
-            auto episode_frame_numbers = nb::steal(nb::detail::ndarray_new(
-                nb::handle(nb::dtype<int>().raw_dtype()),
-                1, env_shape, nb::handle(nullptr), nullptr, nb::dtype<int>()));
-
-            // Cast to typed arrays
-            auto rewards_array = nb::cast<nb::ndarray<nb::numpy, int>>(rewards);
-            auto terminations_array = nb::cast<nb::ndarray<nb::numpy, bool>>(terminations);
-            auto truncations_array = nb::cast<nb::ndarray<nb::numpy, bool>>(truncations);
-            auto env_ids_array = nb::cast<nb::ndarray<nb::numpy, int>>(env_ids);
-            auto lives_array = nb::cast<nb::ndarray<nb::numpy, int>>(lives);
-            auto frame_numbers_array = nb::cast<nb::ndarray<nb::numpy, int>>(frame_numbers);
-            auto episode_frame_numbers_array = nb::cast<nb::ndarray<nb::numpy, int>>(episode_frame_numbers);
+            // Get pointers to the arrays' data
+            auto observations_ptr = observations.data();
+            auto rewards_ptr = rewards.data();
+            auto terminations_ptr = terminations.data();
+            auto truncations_ptr = truncations.data();
+            auto env_ids_ptr = env_ids.data();
+            auto lives_ptr = lives.data();
+            auto frame_numbers_ptr = frame_numbers.data();
+            auto episode_frame_numbers_ptr = episode_frame_numbers.data();
 
             // Copy data from observations to NumPy arrays
+            int channels = self.is_grayscale() ? 1 : 3;
             const size_t obs_size = stack_num * height * width * channels;
-            auto observations_ptr = observations.data();
-
             for (int i = 0; i < num_envs; i++) {
                 const auto& timestep = timesteps[i];
 
@@ -192,13 +153,160 @@ void init_vector_module(nb::module_& m) {
                 );
 
                 // Copy other fields
-                rewards_array.data()[i] = timestep.reward;
-                terminations_array.data()[i] = timestep.terminated;
-                truncations_array.data()[i] = timestep.truncated;
-                env_ids_array.data()[i] = timestep.env_id;
-                lives_array.data()[i] = timestep.lives;
-                frame_numbers_array.data()[i] = timestep.frame_number;
-                episode_frame_numbers_array.data()[i] = timestep.episode_frame_number;
+                rewards_ptr[i] = timestep.reward;
+                terminations_ptr[i] = timestep.terminated;
+                truncations_ptr[i] = timestep.truncated;
+                env_ids_ptr[i] = timestep.env_id;
+                lives_ptr[i] = timestep.lives;
+                frame_numbers_ptr[i] = timestep.frame_number;
+                episode_frame_numbers_ptr[i] = timestep.episode_frame_number;
+            }
+
+            // Create info dict
+            nb::dict info;
+            info["env_id"] = env_ids;
+            info["lives"] = lives;
+            info["frame_number"] = frame_numbers;
+            info["episode_frame_number"] = episode_frame_numbers;
+
+            return nb::make_tuple(observations, rewards, terminations, truncations, info);
+        })::numpy, uint8_t>(
+                    nb::steal(nb::detail::ndarray_new(
+                        nb::handle(nb::type<uint8_t>().raw_type()),
+                        5,
+                        new size_t[5]{size_t(num_envs), size_t(stack_num), size_t(height), size_t(width), size_t(3)},
+                        nb::handle(),
+                        nullptr,
+                        nb::dtype<uint8_t>(),
+                        nb::device::cpu::value,
+                        0,
+                        'C'
+                    ))
+                );
+            }
+
+            auto rewards = nb::ndarray<nb::numpy, int>(
+                nb::steal(nb::detail::ndarray_new(
+                    nb::handle(nb::type<int>().raw_type()),
+                    1,
+                    new size_t[1]{size_t(num_envs)},
+                    nb::handle(),
+                    nullptr,
+                    nb::dtype<int>(),
+                    nb::device::cpu::value,
+                    0,
+                    'C'
+                ))
+            );
+            auto terminations = nb::ndarray<nb::numpy, bool>(
+                nb::steal(nb::detail::ndarray_new(
+                    nb::handle(nb::type<bool>().raw_type()),
+                    1,
+                    new size_t[1]{size_t(num_envs)},
+                    nb::handle(),
+                    nullptr,
+                    nb::dtype<bool>(),
+                    nb::device::cpu::value,
+                    0,
+                    'C'
+                ))
+            );
+            auto truncations = nb::ndarray<nb::numpy, bool>(
+                nb::steal(nb::detail::ndarray_new(
+                    nb::handle(nb::type<bool>().raw_type()),
+                    1,
+                    new size_t[1]{size_t(num_envs)},
+                    nb::handle(),
+                    nullptr,
+                    nb::dtype<bool>(),
+                    nb::device::cpu::value,
+                    0,
+                    'C'
+                ))
+            );
+            auto env_ids = nb::ndarray<nb::numpy, int>(
+                nb::steal(nb::detail::ndarray_new(
+                    nb::handle(nb::type<int>().raw_type()),
+                    1,
+                    new size_t[1]{size_t(num_envs)},
+                    nb::handle(),
+                    nullptr,
+                    nb::dtype<int>(),
+                    nb::device::cpu::value,
+                    0,
+                    'C'
+                ))
+            );
+            auto lives = nb::ndarray<nb::numpy, int>(
+                nb::steal(nb::detail::ndarray_new(
+                    nb::handle(nb::type<int>().raw_type()),
+                    1,
+                    new size_t[1]{size_t(num_envs)},
+                    nb::handle(),
+                    nullptr,
+                    nb::dtype<int>(),
+                    nb::device::cpu::value,
+                    0,
+                    'C'
+                ))
+            );
+            auto frame_numbers = nb::ndarray<nb::numpy, int>(
+                nb::steal(nb::detail::ndarray_new(
+                    nb::handle(nb::type<int>().raw_type()),
+                    1,
+                    new size_t[1]{size_t(num_envs)},
+                    nb::handle(),
+                    nullptr,
+                    nb::dtype<int>(),
+                    nb::device::cpu::value,
+                    0,
+                    'C'
+                ))
+            );
+            auto episode_frame_numbers = nb::ndarray<nb::numpy, int>(
+                nb::steal(nb::detail::ndarray_new(
+                    nb::handle(nb::type<int>().raw_type()),
+                    1,
+                    new size_t[1]{size_t(num_envs)},
+                    nb::handle(),
+                    nullptr,
+                    nb::dtype<int>(),
+                    nb::device::cpu::value,
+                    0,
+                    'C'
+                ))
+            );
+
+            // Get pointers to the arrays' data
+            auto observations_ptr = observations.data();
+            auto rewards_ptr = rewards.data();
+            auto terminations_ptr = terminations.data();
+            auto truncations_ptr = truncations.data();
+            auto env_ids_ptr = env_ids.data();
+            auto lives_ptr = lives.data();
+            auto frame_numbers_ptr = frame_numbers.data();
+            auto episode_frame_numbers_ptr = episode_frame_numbers.data();
+
+            // Copy data from observations to NumPy arrays
+            const size_t obs_size = stack_num * height * width * channels;
+            for (int i = 0; i < num_envs; i++) {
+                const auto& timestep = timesteps[i];
+
+                // Copy screen data
+                std::memcpy(
+                    observations_ptr + i * obs_size,
+                    timestep.observation.data(),
+                    obs_size * sizeof(uint8_t)
+                );
+
+                // Copy other fields
+                rewards_ptr[i] = timestep.reward;
+                terminations_ptr[i] = timestep.terminated;
+                truncations_ptr[i] = timestep.truncated;
+                env_ids_ptr[i] = timestep.env_id;
+                lives_ptr[i] = timestep.lives;
+                frame_numbers_ptr[i] = timestep.frame_number;
+                episode_frame_numbers_ptr[i] = timestep.episode_frame_number;
             }
 
             // Create info dict
@@ -225,13 +333,8 @@ void init_vector_module(nb::module_& m) {
             auto ptr = self.get_vectorizer();
 
             // Create a NumPy array with the correct size to hold the pointer
-            size_t shape[1] = {sizeof(ptr)};
-            auto handle_array = nb::steal(nb::detail::ndarray_new(
-                nb::handle(nb::dtype<uint8_t>().raw_dtype()),
-                1, shape, nb::handle(nullptr), nullptr, nb::dtype<uint8_t>()));
-
-            auto handle_typed = nb::cast<nb::ndarray<nb::numpy, uint8_t>>(handle_array);
-            auto handle_ptr = handle_typed.data();
+            auto handle_array = nb::ndarray<nb::numpy, uint8_t>(nullptr, {sizeof(ptr)});
+            auto handle_ptr = handle_array.data();
 
             // Copy the pointer value into the byte array
             std::memcpy(handle_ptr, &ptr, sizeof(ptr));

--- a/src/ale/python/ale_vector_python_interface.hpp
+++ b/src/ale/python/ale_vector_python_interface.hpp
@@ -11,12 +11,6 @@
 #include "ale/vector/preprocessed_env.hpp"
 #include "ale/vector/utils.hpp"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/stl/filesystem.h>
-#include <pybind11/numpy.h>
-
-namespace py = pybind11;
 namespace fs = std::filesystem;
 
 namespace ale::vector {

--- a/src/ale/python/ale_vector_python_interface.hpp
+++ b/src/ale/python/ale_vector_python_interface.hpp
@@ -11,6 +11,12 @@
 #include "ale/vector/preprocessed_env.hpp"
 #include "ale/vector/utils.hpp"
 
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/stl/filesystem.h>
+
+namespace nb = nanobind;
 namespace fs = std::filesystem;
 
 namespace ale::vector {

--- a/src/ale/python/ale_vector_xla_interface.cpp
+++ b/src/ale/python/ale_vector_xla_interface.cpp
@@ -2,15 +2,15 @@
 
 #include "ale/vector/async_vectorizer.hpp"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/numpy.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
 
 #include <vector>
 #include <cstring>  // For memcpy
 #include <iostream>
 
 namespace ffi = xla::ffi;
-namespace py = pybind11;
+namespace nb = nanobind;
 
 ffi::Error XLAResetImpl(
     ffi::Buffer<ffi::U8> handle_buffer,
@@ -231,14 +231,14 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
 );
 
 template <typename T>
-py::capsule EncapsulateFFICall(T *fn) {
+nb::capsule EncapsulateFFICall(T *fn) {
     // This check is optional, but it can be helpful for avoiding invalid handlers.
     static_assert(std::is_invocable_r_v<XLA_FFI_Error *, T, XLA_FFI_CallFrame *>,
                   "Encapsulated function must be and XLA FFI handler");
-    return py::capsule(reinterpret_cast<void *>(fn));
+    return nb::capsule(reinterpret_cast<void *>(fn));
 }
 
-void init_vector_module_xla(py::module& m) {
+void init_vector_module_xla(nb::module_& m) {
     m.def("VectorXLAReset", [] {return EncapsulateFFICall(AtariVectorEnvXLAReset); });
     m.def("VectorXLAStep", [] {return EncapsulateFFICall(AtariVectorEnvXLAStep);});
 }


### PR DESCRIPTION
Nanobind (https://nanobind.readthedocs.io/en/latest/index.html) [benchmarks](https://nanobind.readthedocs.io/en/latest/benchmark.html#benchmarks) show up to ~4× faster compile time, ~5× smaller binaries, and ~10× lower runtime overheads compared to pybind11.

Therefore, it's been proposed as a feature to add in https://github.com/Farama-Foundation/Arcade-Learning-Environment/issues/494

This PR replaces pybind11 to nanobind with the power of claude 4