### PR TITLE
Environment parametrize vector testing

### DIFF
--- a/src/ale/python/ale_vector_xla_interface.cpp
+++ b/src/ale/python/ale_vector_xla_interface.cpp
@@ -64,10 +64,10 @@ ffi::Error XLAResetImpl(
             return ffi::Error::Internal("Number of timesteps is wrong");
         }
 
-        size_t obs_size = vectorizer->get_obs_size();
+        size_t stacked_obs_size = vectorizer->get_stacked_obs_size();
 
         // Check if the observations buffer is large enough
-        if (observations_buffer->element_count() != vectorizer->get_batch_size() * obs_size) {
+        if (observations_buffer->element_count() != vectorizer->get_batch_size() * stacked_obs_size) {
             return ffi::Error::Internal("Observations buffer is the wrong size");
         }
 
@@ -75,9 +75,9 @@ ffi::Error XLAResetImpl(
             const auto& timestep = timesteps[i];
 
             std::memcpy(
-                observations_buffer->typed_data() + i * obs_size,
+                observations_buffer->typed_data() + i * stacked_obs_size,
                 timestep.observation.data(),
-                obs_size
+                stacked_obs_size
             );
             env_ids_buffer->typed_data()[i] = timestep.env_id;
             lives_buffer->typed_data()[i] = timestep.lives;
@@ -175,10 +175,10 @@ ffi::Error XLAStepImpl(
             return ffi::Error::Internal("Number of timesteps is wrong");
         }
 
-        size_t obs_size = vectorizer->get_obs_size();
+        size_t stacked_obs_size = vectorizer->get_stacked_obs_size();
 
         // Check if the observations buffer is large enough
-        if (observations_buffer->element_count() != vectorizer->get_batch_size() * obs_size) {
+        if (observations_buffer->element_count() != vectorizer->get_batch_size() * stacked_obs_size) {
             return ffi::Error::Internal("Observations buffer is the wrong size");
         }
 
@@ -186,9 +186,9 @@ ffi::Error XLAStepImpl(
             const auto& timestep = timesteps[i];
 
             std::memcpy(
-                observations_buffer->typed_data() + i * obs_size,
+                observations_buffer->typed_data() + i * stacked_obs_size,
                 timestep.observation.data(),
-                obs_size
+                stacked_obs_size
             );
             rewards_buffer->typed_data()[i] = timestep.reward;
             terminations_buffer->typed_data()[i] = timestep.terminated;

--- a/src/ale/python/env.py
+++ b/src/ale/python/env.py
@@ -296,6 +296,9 @@ class AtariEnv(gymnasium.Env, utils.EzPickle):
 
             strength = action[0]
         else:
+            assert (
+                action in self._action_set
+            ), f"{action} isn't within the action_set ({self._action_set})"
             action_idx = self._action_set[action]
             strength = 1.0
 

--- a/src/ale/python/env.py
+++ b/src/ale/python/env.py
@@ -296,9 +296,6 @@ class AtariEnv(gymnasium.Env, utils.EzPickle):
 
             strength = action[0]
         else:
-            assert (
-                action in self._action_set
-            ), f"{action} isn't within the action_set ({self._action_set})"
             action_idx = self._action_set[action]
             strength = 1.0
 

--- a/src/ale/python/vector_env.py
+++ b/src/ale/python/vector_env.py
@@ -253,6 +253,7 @@ class AtariVectorEnv(VectorEnv):
                     ),  # episode frame number
                 ),
                 vmap_method="broadcast_all",
+                has_side_effect=True,
             )
 
             if reset_mask is not None:
@@ -331,6 +332,7 @@ class AtariVectorEnv(VectorEnv):
                     ),  # episode frame number
                 ),
                 vmap_method="broadcast_all",
+                has_side_effect=True,
             )
 
             (

--- a/src/ale/vector/async_vectorizer.hpp
+++ b/src/ale/vector/async_vectorizer.hpp
@@ -50,7 +50,7 @@ namespace ale::vector {
             for (int i = 0; i < num_envs_; ++i) {
                 envs_[i] = env_factory(i);
             }
-            obs_size_ = envs_[0]->get_obs_size();
+            stacked_obs_size_ = envs_[0]->get_stacked_obs_size();
 
             // Setup worker threads
             const std::size_t processor_count = std::thread::hardware_concurrency();
@@ -166,8 +166,8 @@ namespace ale::vector {
             return batch_size_;
         }
 
-        int get_obs_size() const {
-            return obs_size_;
+        int get_stacked_obs_size() const {
+            return stacked_obs_size_;
         }
 
     private:
@@ -175,7 +175,7 @@ namespace ale::vector {
         int batch_size_;                                  // Batch size for processing
         int num_threads_;                                 // Number of worker threads
         bool is_sync_;                                    // Whether to operate in synchronous mode
-        int obs_size_;                                    // The observation size (height * width * channels)
+        int stacked_obs_size_;                            // The observation size (stack-num * height * width * channels)
 
         std::atomic<bool> stop_;                          // Signal to stop worker threads
         std::vector<std::thread> workers_;                // Worker threads

--- a/tests/python/test_atari_vector_env.py
+++ b/tests/python/test_atari_vector_env.py
@@ -1,65 +1,12 @@
 """Test equivalence between Gymnasium and Vector environments."""
 
+import ale_py
 import gymnasium as gym
 import numpy as np
 import pytest
-from ale_py.vector_env import AtariVectorEnv
 from gymnasium.utils.env_checker import data_equivalence
 
-
-@pytest.mark.parametrize("num_envs", [1, 3])
-@pytest.mark.parametrize("stack_num", [4, 6])
-@pytest.mark.parametrize("img_height, img_width", [(84, 84), (210, 160)])
-@pytest.mark.parametrize("grayscale", [True, False])
-def test_reset_step_shapes(num_envs, stack_num, img_height, img_width, grayscale):
-    """Test if reset returns observations with the correct shape."""
-    envs = AtariVectorEnv(
-        game="breakout",
-        num_envs=num_envs,
-        stack_num=stack_num,
-        img_height=img_height,
-        img_width=img_width,
-        grayscale=grayscale,
-    )
-
-    expected_shape = (num_envs, stack_num, img_height, img_width)
-    if not grayscale:
-        expected_shape += (3,)
-
-    assert envs.num_envs == num_envs
-    assert envs.observation_space.shape == expected_shape
-    assert envs.action_space.shape == (num_envs,)
-
-    obs, info = envs.reset(seed=0)
-
-    assert isinstance(obs, np.ndarray)
-    assert obs.shape == expected_shape
-    assert obs.dtype == np.uint8
-    assert obs in envs.observation_space, f"{envs.observation_space=}"
-    assert isinstance(info, dict)
-    assert all(
-        isinstance(val, np.ndarray) and len(val) == num_envs for val in info.values()
-    )
-
-    actions = envs.action_space.sample()
-    obs, reward, terminations, truncations, info = envs.step(actions)
-
-    assert isinstance(obs, np.ndarray)
-    assert obs.shape == expected_shape
-    assert obs.dtype == np.uint8
-    assert obs in envs.observation_space, f"{envs.observation_space=}"
-    assert isinstance(reward, np.ndarray) and reward.dtype == np.int32
-    assert reward.shape == (num_envs,)
-    assert isinstance(terminations, np.ndarray) and terminations.dtype == bool
-    assert terminations.shape == (num_envs,)
-    assert isinstance(truncations, np.ndarray) and truncations.dtype == bool
-    assert truncations.shape == (num_envs,)
-    assert isinstance(info, dict)
-    assert all(
-        isinstance(val, np.ndarray) and len(val) == num_envs for val in info.values()
-    )
-
-    envs.close()
+gym.register_envs(ale_py)
 
 
 def obs_equivalence(obs_1, obs_2, i, **log_kwargs):
@@ -143,222 +90,263 @@ def assert_gym_ale_rollout_equivalence(
     ale_envs.close()
 
 
-@pytest.mark.parametrize("stack_num", [4, 6])
-@pytest.mark.parametrize("img_height, img_width", [(84, 84), (210, 160)])
-@pytest.mark.parametrize("frame_skip", [1, 4])
-@pytest.mark.parametrize("grayscale", [False, True])
-def test_obs_params_equivalence(
-    stack_num, img_height, img_width, frame_skip, grayscale, num_envs=8
-):
-    gym_envs = gym.vector.SyncVectorEnv(
-        [
-            lambda: gym.wrappers.FrameStackObservation(
-                gym.wrappers.AtariPreprocessing(
-                    gym.make("BreakoutNoFrameskip-v4"),
-                    noop_max=0,
-                    frame_skip=frame_skip,
-                    screen_size=(img_width, img_height),
-                    grayscale_obs=grayscale,
-                ),
-                stack_size=stack_num,
-                padding_type="zero",
-            )
-            for _ in range(num_envs)
-        ],
-    )
-    ale_envs = AtariVectorEnv(
-        game="breakout",
-        num_envs=num_envs,
-        frameskip=frame_skip,
-        img_height=img_height,
-        img_width=img_width,
-        stack_num=stack_num,
-        noop_max=0,
-        use_fire_reset=False,
-        maxpool=frame_skip > 1,
-        grayscale=grayscale,
-    )
+@pytest.mark.parametrize("env_id", ["ALE/Breakout-v5"])
+class TestVectorEnv:
 
-    assert_gym_ale_rollout_equivalence(
-        gym_envs,
-        ale_envs,
-        stack_num=stack_num,
-        img_height=img_height,
-        img_width=img_width,
-        frame_skip=frame_skip,
-        grayscale=grayscale,
-    )
+    disable_vector_args = dict()
+    disable_env_args = dict()
+    disable_preprocessing_args = dict()
 
+    @pytest.mark.parametrize("num_envs", [1, 3])
+    @pytest.mark.parametrize("stack_num", [4, 6])
+    @pytest.mark.parametrize("img_height, img_width", [(84, 84), (210, 160)])
+    @pytest.mark.parametrize("grayscale", [True, False])
+    def test_reset_step_shapes(
+        self, env_id, num_envs, stack_num, img_height, img_width, grayscale
+    ):
+        """Test if reset returns observations with the correct shape."""
+        envs = gym.make_vec(
+            env_id,
+            num_envs,
+            stack_num=stack_num,
+            img_height=img_height,
+            img_width=img_width,
+            grayscale=grayscale,
+        )
 
-@pytest.mark.parametrize("continuous_action_threshold", (0.2, 0.5, 0.8))
-def test_continuous_equivalence(continuous_action_threshold, num_envs=8):
-    gym_envs = gym.vector.SyncVectorEnv(
-        [
-            lambda: gym.wrappers.FrameStackObservation(
-                gym.wrappers.AtariPreprocessing(
-                    gym.make(
-                        "BreakoutNoFrameskip-v4",
-                        continuous=True,
-                        continuous_action_threshold=continuous_action_threshold,
+        expected_shape = (num_envs, stack_num, img_height, img_width)
+        if not grayscale:
+            expected_shape += (3,)
+
+        assert envs.num_envs == num_envs
+        assert envs.observation_space.shape == expected_shape
+        assert envs.action_space.shape == (num_envs,)
+
+        obs, info = envs.reset(seed=0)
+
+        assert isinstance(obs, np.ndarray)
+        assert obs.shape == expected_shape
+        assert obs.dtype == np.uint8
+        assert obs in envs.observation_space, f"{envs.observation_space=}"
+        assert isinstance(info, dict)
+        assert all(
+            isinstance(val, np.ndarray) and len(val) == num_envs
+            for val in info.values()
+        )
+
+        actions = envs.action_space.sample()
+        obs, reward, terminations, truncations, info = envs.step(actions)
+
+        assert isinstance(obs, np.ndarray)
+        assert obs.shape == expected_shape
+        assert obs.dtype == np.uint8
+        assert obs in envs.observation_space, f"{envs.observation_space=}"
+        assert isinstance(reward, np.ndarray) and reward.dtype == np.int32
+        assert reward.shape == (num_envs,)
+        assert isinstance(terminations, np.ndarray) and terminations.dtype == bool
+        assert terminations.shape == (num_envs,)
+        assert isinstance(truncations, np.ndarray) and truncations.dtype == bool
+        assert truncations.shape == (num_envs,)
+        assert isinstance(info, dict)
+        assert all(
+            isinstance(val, np.ndarray) and len(val) == num_envs
+            for val in info.values()
+        )
+
+        envs.close()
+
+    @pytest.mark.parametrize("stack_num", [4, 6])
+    @pytest.mark.parametrize("img_height, img_width", [(84, 84), (210, 160)])
+    @pytest.mark.parametrize("frame_skip", [1, 4])
+    @pytest.mark.parametrize("grayscale", [False, True])
+    def test_obs_params_equivalence(
+        self,
+        env_id,
+        stack_num,
+        img_height,
+        img_width,
+        frame_skip,
+        grayscale,
+        num_envs=8,
+    ):
+        gym_envs = gym.vector.SyncVectorEnv(
+            [
+                lambda: gym.wrappers.FrameStackObservation(
+                    gym.wrappers.AtariPreprocessing(
+                        gym.make(env_id),
+                        frame_skip=frame_skip,
+                        screen_size=(img_width, img_height),
+                        grayscale_obs=grayscale,
+                        **self.disable_preprocessing_args,
                     ),
-                    noop_max=0,
-                ),
-                stack_size=4,
-                padding_type="zero",
-            )
-            for _ in range(num_envs)
-        ],
+                    stack_size=stack_num,
+                    padding_type="zero",
+                )
+                for _ in range(num_envs)
+            ],
+        )
+        ale_envs = gym.make_vec(
+            env_id,
+            num_envs,
+            frameskip=frame_skip,
+            img_height=img_height,
+            img_width=img_width,
+            stack_num=stack_num,
+            maxpool=frame_skip > 1,
+            grayscale=grayscale,
+            **self.disable_vector_args,
+        )
+
+        assert_gym_ale_rollout_equivalence(
+            gym_envs,
+            ale_envs,
+            stack_num=stack_num,
+            img_height=img_height,
+            img_width=img_width,
+            frame_skip=frame_skip,
+            grayscale=grayscale,
+        )
+
+    @pytest.mark.parametrize("continuous_action_threshold", (0.2, 0.5, 0.8))
+    def test_continuous_equivalence(
+        self, env_id, continuous_action_threshold, num_envs=8
+    ):
+        gym_envs = gym.vector.SyncVectorEnv(
+            [
+                lambda: gym.wrappers.FrameStackObservation(
+                    gym.wrappers.AtariPreprocessing(
+                        gym.make(
+                            env_id,
+                            continuous=True,
+                            continuous_action_threshold=continuous_action_threshold,
+                            **self.disable_env_args,
+                        ),
+                        noop_max=0,
+                    ),
+                    stack_size=4,
+                    padding_type="zero",
+                )
+                for _ in range(num_envs)
+            ],
+        )
+        ale_envs = gym.make_vec(
+            env_id,
+            num_envs,
+            continuous=True,
+            continuous_action_threshold=continuous_action_threshold,
+            **self.disable_vector_args,
+        )
+
+        assert_gym_ale_rollout_equivalence(
+            gym_envs,
+            ale_envs,
+            continuous=True,
+            continuous_action_threshold=continuous_action_threshold,
+        )
+
+    @pytest.mark.parametrize(
+        "num_envs, seeds",
+        [(1, np.array([0])), (3, np.array([1, 2, 3])), (10, np.arange(10))],
     )
-    ale_envs = AtariVectorEnv(
-        game="breakout",
-        num_envs=num_envs,
-        noop_max=0,
-        use_fire_reset=False,
-        continuous=True,
-        continuous_action_threshold=continuous_action_threshold,
-    )
+    @pytest.mark.parametrize("noop_max", (0, 10, 30))
+    @pytest.mark.parametrize("repeat_action_probability", (0.0, 0.25))
+    @pytest.mark.parametrize("use_fire_reset", [False, True])
+    def test_determinism(
+        self,
+        env_id,
+        num_envs: int,
+        seeds: np.ndarray,
+        noop_max: int,
+        repeat_action_probability: float,
+        use_fire_reset: bool,
+        game: str = "pong",
+        rollout_length: int = 100,
+    ):
+        envs_1 = gym.make_vec(
+            env_id,
+            num_envs,
+            noop_max=noop_max,
+            repeat_action_probability=repeat_action_probability,
+            use_fire_reset=use_fire_reset,
+        )
+        envs_2 = gym.make_vec(
+            env_id,
+            num_envs,
+            noop_max=noop_max,
+            repeat_action_probability=repeat_action_probability,
+            use_fire_reset=use_fire_reset,
+        )
 
-    assert_gym_ale_rollout_equivalence(
-        gym_envs,
-        ale_envs,
-        continuous=True,
-        continuous_action_threshold=continuous_action_threshold,
-    )
-
-
-@pytest.mark.parametrize(
-    "num_envs, seeds",
-    [(1, np.array([0])), (3, np.array([1, 2, 3])), (10, np.arange(10))],
-)
-@pytest.mark.parametrize("noop_max", (0, 10, 30))
-@pytest.mark.parametrize("repeat_action_probability", (0.0, 0.25))
-@pytest.mark.parametrize("use_fire_reset", [False, True])
-def test_determinism(
-    num_envs: int,
-    seeds: np.ndarray,
-    noop_max: int,
-    repeat_action_probability: float,
-    use_fire_reset: bool,
-    game: str = "pong",
-    rollout_length: int = 100,
-):
-    envs_1 = AtariVectorEnv(
-        game,
-        num_envs=num_envs,
-        noop_max=noop_max,
-        repeat_action_probability=repeat_action_probability,
-        use_fire_reset=use_fire_reset,
-    )
-    envs_2 = AtariVectorEnv(
-        game,
-        num_envs=num_envs,
-        noop_max=noop_max,
-        repeat_action_probability=repeat_action_probability,
-        use_fire_reset=use_fire_reset,
-    )
-
-    obs_1, info_1 = envs_1.reset(seed=seeds)
-    obs_2, info_2 = envs_2.reset(seed=seeds)
-
-    assert data_equivalence(obs_1, obs_2)
-    assert data_equivalence(info_1, info_2)
-
-    for i in range(rollout_length):
-        actions = envs_1.action_space.sample()
-
-        obs_1, rewards_1, terminations_1, truncations_1, info_1 = envs_1.step(actions)
-        obs_2, rewards_2, terminations_2, truncations_2, info_2 = envs_2.step(actions)
+        obs_1, info_1 = envs_1.reset(seed=seeds)
+        obs_2, info_2 = envs_2.reset(seed=seeds)
 
         assert data_equivalence(obs_1, obs_2)
-        assert data_equivalence(rewards_1, rewards_2)
-        assert data_equivalence(terminations_1, terminations_2)
-        assert data_equivalence(truncations_1, truncations_2)
         assert data_equivalence(info_1, info_2)
 
-    envs_1.close()
-    envs_2.close()
+        for i in range(rollout_length):
+            actions = envs_1.action_space.sample()
 
+            obs_1, rewards_1, terminations_1, truncations_1, info_1 = envs_1.step(
+                actions
+            )
+            obs_2, rewards_2, terminations_2, truncations_2, info_2 = envs_2.step(
+                actions
+            )
 
-def test_batch_size_async(
-    batch_size=4, num_envs=8, rollout_length=100, reset_seed=123, action_seed=123
-):
-    """Tests asynchronous feature of the vector environment.
+            assert data_equivalence(obs_1, obs_2)
+            assert data_equivalence(rewards_1, rewards_2)
+            assert data_equivalence(terminations_1, terminations_2)
+            assert data_equivalence(truncations_1, truncations_2)
+            assert data_equivalence(info_1, info_2)
 
-    Using a batch_size < num_envs then the first N sub-environments results are returned.
-    We use the synchronous (all sub-environments) as the baseline and compare a sub-environment's results
-       to for the synchronous's result for the same action.
-    """
-    sync_envs = AtariVectorEnv(game="pong", num_envs=num_envs)
-    async_envs = AtariVectorEnv(game="pong", num_envs=num_envs, batch_size=batch_size)
-    assert sync_envs.num_envs == async_envs.num_envs
+        envs_1.close()
+        envs_2.close()
 
-    assert sync_envs.single_action_space == async_envs.single_action_space
-    assert sync_envs.single_observation_space == async_envs.single_observation_space
-    assert sync_envs.action_space != async_envs.action_space
-    assert sync_envs.observation_space != async_envs.observation_space
+    def test_batch_size_async(
+        self,
+        env_id,
+        batch_size=4,
+        num_envs=8,
+        rollout_length=100,
+        reset_seed=123,
+        action_seed=123,
+    ):
+        """Tests asynchronous feature of the vector environment.
 
-    sync_envs.action_space.seed(action_seed)
-    actions = [sync_envs.action_space.sample() for _ in range(rollout_length)]
-    async_env_timestep = np.zeros(num_envs, dtype=np.int32)
+        Using a batch_size < num_envs then the first N sub-environments results are returned.
+        We use the synchronous (all sub-environments) as the baseline and compare a sub-environment's results
+           to for the synchronous's result for the same action.
+        """
+        sync_envs = gym.make_vec(env_id, num_envs)
+        async_envs = gym.make_vec(env_id, num_envs, batch_size=batch_size)
+        assert sync_envs.num_envs == async_envs.num_envs
 
-    sync_obs, sync_info = sync_envs.reset(seed=reset_seed)
-    sync_env_ids = sync_info.pop("env_id")
-    assert np.all(sync_env_ids == np.arange(num_envs)), f"{sync_env_ids=}"
-    async_obs, async_info = async_envs.reset(seed=reset_seed)
-    async_env_ids = async_info.pop("env_id")
-    assert async_env_ids.shape == (batch_size,), f"{async_env_ids=}"
+        assert sync_envs.single_action_space == async_envs.single_action_space
+        assert sync_envs.single_observation_space == async_envs.single_observation_space
+        assert sync_envs.action_space != async_envs.action_space
+        assert sync_envs.observation_space != async_envs.observation_space
 
-    sync_observations = [sync_obs]
-    sync_rewards = [np.zeros(num_envs, dtype=np.int32)]
-    sync_terminations = [np.zeros(num_envs, dtype=bool)]
-    sync_truncations = [np.zeros(num_envs, dtype=bool)]
-    sync_infos = [sync_info]
+        sync_envs.action_space.seed(action_seed)
+        actions = [sync_envs.action_space.sample() for _ in range(rollout_length)]
+        async_env_timestep = np.zeros(num_envs, dtype=np.int32)
 
-    for async_i, env_id in enumerate(async_env_ids):
-        async_t = async_env_timestep[env_id]
-        assert data_equivalence(sync_observations[async_t][env_id], async_obs[async_i])
-        assert all(
-            data_equivalence(sync_infos[async_t][key][env_id], async_info[key][async_i])
-            for key in sync_info
-        )
-    async_env_timestep[async_env_ids] += 1
-
-    for t in range(rollout_length):
-        obs, rewards, terminations, truncations, info = sync_envs.step(actions[t])
-        sync_observations.append(obs)
-        sync_rewards.append(rewards)
-        sync_terminations.append(terminations)
-        sync_truncations.append(truncations)
-        sync_env_ids = info.pop("env_id")
+        sync_obs, sync_info = sync_envs.reset(seed=reset_seed)
+        sync_env_ids = sync_info.pop("env_id")
         assert np.all(sync_env_ids == np.arange(num_envs)), f"{sync_env_ids=}"
-        sync_infos.append(info)
-
-        async_actions = np.array(
-            [
-                actions[async_env_timestep[env_id] - 1][env_id]
-                for env_id in async_env_ids
-            ]
-        )
-        async_obs, async_rewards, async_terminations, async_truncations, async_info = (
-            async_envs.step(async_actions)
-        )
+        async_obs, async_info = async_envs.reset(seed=reset_seed)
         async_env_ids = async_info.pop("env_id")
         assert async_env_ids.shape == (batch_size,), f"{async_env_ids=}"
 
+        sync_observations = [sync_obs]
+        sync_rewards = [np.zeros(num_envs, dtype=np.int32)]
+        sync_terminations = [np.zeros(num_envs, dtype=bool)]
+        sync_truncations = [np.zeros(num_envs, dtype=bool)]
+        sync_infos = [sync_info]
+
         for async_i, env_id in enumerate(async_env_ids):
             async_t = async_env_timestep[env_id]
-
             assert data_equivalence(
                 sync_observations[async_t][env_id], async_obs[async_i]
-            )
-            assert data_equivalence(
-                sync_rewards[async_t][env_id], async_rewards[async_i]
-            )
-            assert data_equivalence(
-                sync_terminations[async_t][env_id], async_terminations[async_i]
-            )
-            assert data_equivalence(
-                sync_truncations[async_t][env_id], async_truncations[async_i]
             )
             assert all(
                 data_equivalence(
@@ -368,119 +356,160 @@ def test_batch_size_async(
             )
         async_env_timestep[async_env_ids] += 1
 
-    sync_envs.close()
-    async_envs.close()
+        for t in range(rollout_length):
+            obs, rewards, terminations, truncations, info = sync_envs.step(actions[t])
+            sync_observations.append(obs)
+            sync_rewards.append(rewards)
+            sync_terminations.append(terminations)
+            sync_truncations.append(truncations)
+            sync_env_ids = info.pop("env_id")
+            assert np.all(sync_env_ids == np.arange(num_envs)), f"{sync_env_ids=}"
+            sync_infos.append(info)
 
-
-def test_episodic_life_equivalence(num_envs=8):
-    gym_envs = gym.vector.SyncVectorEnv(
-        [
-            lambda: gym.wrappers.FrameStackObservation(
-                gym.wrappers.AtariPreprocessing(
-                    gym.make(
-                        "BreakoutNoFrameskip-v4",
-                    ),
-                    noop_max=0,
-                    terminal_on_life_loss=True,
-                ),
-                stack_size=4,
-                padding_type="zero",
+            async_actions = np.array(
+                [
+                    actions[async_env_timestep[env_id] - 1][env_id]
+                    for env_id in async_env_ids
+                ]
             )
-            for _ in range(num_envs)
-        ],
-    )
-    ale_envs = AtariVectorEnv(
-        game="breakout",
-        num_envs=num_envs,
-        noop_max=0,
-        use_fire_reset=False,
-        episodic_life=True,
-    )
+            (
+                async_obs,
+                async_rewards,
+                async_terminations,
+                async_truncations,
+                async_info,
+            ) = async_envs.step(async_actions)
+            async_env_ids = async_info.pop("env_id")
+            assert async_env_ids.shape == (batch_size,), f"{async_env_ids=}"
 
-    assert_gym_ale_rollout_equivalence(gym_envs, ale_envs, episodic_life=True)
+            for async_i, env_id in enumerate(async_env_ids):
+                async_t = async_env_timestep[env_id]
 
+                assert data_equivalence(
+                    sync_observations[async_t][env_id], async_obs[async_i]
+                )
+                assert data_equivalence(
+                    sync_rewards[async_t][env_id], async_rewards[async_i]
+                )
+                assert data_equivalence(
+                    sync_terminations[async_t][env_id], async_terminations[async_i]
+                )
+                assert data_equivalence(
+                    sync_truncations[async_t][env_id], async_truncations[async_i]
+                )
+                assert all(
+                    data_equivalence(
+                        sync_infos[async_t][key][env_id], async_info[key][async_i]
+                    )
+                    for key in sync_info
+                )
+            async_env_timestep[async_env_ids] += 1
 
-def test_episodic_life_and_life_loss_info(
-    num_envs=8, rollout_length=1000, reset_seed=123, action_seed=123
-):
-    standard_envs = AtariVectorEnv(game="breakout", num_envs=num_envs)
-    episodic_life_envs = AtariVectorEnv(
-        game="breakout", num_envs=num_envs, episodic_life=True
-    )
-    life_loss_envs = AtariVectorEnv(
-        game="breakout", num_envs=num_envs, life_loss_info=True
-    )
+        sync_envs.close()
+        async_envs.close()
 
-    standard_envs.action_space.seed(action_seed)
-    standard_obs, standard_info = standard_envs.reset(seed=reset_seed)
-    episodic_life_obs, episodic_life_info = episodic_life_envs.reset(seed=reset_seed)
-    life_loss_obs, life_loss_info = life_loss_envs.reset(seed=reset_seed)
-
-    assert data_equivalence(standard_obs, episodic_life_obs)
-    assert data_equivalence(standard_obs, life_loss_obs)
-    assert data_equivalence(standard_info, episodic_life_info)
-    assert data_equivalence(standard_info, life_loss_info)
-
-    previous_lives = standard_info["lives"]
-    assert np.all(previous_lives > 0)
-
-    rollout_life_lost = False
-    for i in range(rollout_length):
-        actions = standard_envs.action_space.sample()
-
-        (
-            standard_obs,
-            standard_rewards,
-            standard_terminations,
-            standard_truncations,
-            standard_info,
-        ) = standard_envs.step(actions)
-        (
-            life_loss_obs,
-            life_loss_rewards,
-            life_loss_terminations,
-            life_loss_truncations,
-            life_loss_info,
-        ) = life_loss_envs.step(actions)
-
-        lives = standard_info["lives"]
-        action_life_lost = previous_lives > lives
-
-        assert obs_equivalence(standard_obs, life_loss_obs, i=i, life_loss=True)
-        assert data_equivalence(standard_rewards, life_loss_rewards)
-        assert np.all(
-            np.logical_or(standard_terminations, action_life_lost)
-            == life_loss_terminations
+    def test_episodic_life_equivalence(self, env_id, num_envs=8):
+        gym_envs = gym.vector.SyncVectorEnv(
+            [
+                lambda: gym.wrappers.FrameStackObservation(
+                    gym.wrappers.AtariPreprocessing(
+                        gym.make(
+                            "BreakoutNoFrameskip-v4",
+                        ),
+                        terminal_on_life_loss=True,
+                        **self.disable_preprocessing_args,
+                    ),
+                    stack_size=4,
+                    padding_type="zero",
+                )
+                for _ in range(num_envs)
+            ],
         )
-        assert data_equivalence(standard_truncations, life_loss_truncations)
+        ale_envs = gym.make_vec(
+            env_id, num_envs, episodic_life=True, **self.disable_vector_args
+        )
+
+        assert_gym_ale_rollout_equivalence(gym_envs, ale_envs, episodic_life=True)
+
+    def test_episodic_life_and_life_loss_info(
+        self, env_id, num_envs=8, rollout_length=1000, reset_seed=123, action_seed=123
+    ):
+        standard_envs = gym.make_vec(env_id, num_envs)
+        episodic_life_envs = gym.make_vec(env_id, num_envs, episodic_life=True)
+        life_loss_envs = gym.make_vec(env_id, num_envs, life_loss_info=True)
+
+        standard_envs.action_space.seed(action_seed)
+        standard_obs, standard_info = standard_envs.reset(seed=reset_seed)
+        episodic_life_obs, episodic_life_info = episodic_life_envs.reset(
+            seed=reset_seed
+        )
+        life_loss_obs, life_loss_info = life_loss_envs.reset(seed=reset_seed)
+
+        assert data_equivalence(standard_obs, episodic_life_obs)
+        assert data_equivalence(standard_obs, life_loss_obs)
+        assert data_equivalence(standard_info, episodic_life_info)
         assert data_equivalence(standard_info, life_loss_info)
 
-        if not rollout_life_lost:
-            rollout_life_lost = life_loss_terminations.any()
+        previous_lives = standard_info["lives"]
+        assert np.all(previous_lives > 0)
+
+        rollout_life_lost = False
+        for i in range(rollout_length):
+            actions = standard_envs.action_space.sample()
 
             (
-                episodic_life_obs,
-                episodic_life_rewards,
-                episodic_life_terminations,
-                episodic_life_truncations,
-                episodic_life_info,
-            ) = episodic_life_envs.step(actions)
+                standard_obs,
+                standard_rewards,
+                standard_terminations,
+                standard_truncations,
+                standard_info,
+            ) = standard_envs.step(actions)
+            (
+                life_loss_obs,
+                life_loss_rewards,
+                life_loss_terminations,
+                life_loss_truncations,
+                life_loss_info,
+            ) = life_loss_envs.step(actions)
 
-            assert obs_equivalence(
-                standard_obs, episodic_life_obs, i=i, episodic_life=True
-            )
-            assert data_equivalence(standard_rewards, episodic_life_rewards)
+            lives = standard_info["lives"]
+            action_life_lost = previous_lives > lives
+
+            assert obs_equivalence(standard_obs, life_loss_obs, i=i, life_loss=True)
+            assert data_equivalence(standard_rewards, life_loss_rewards)
             assert np.all(
                 np.logical_or(standard_terminations, action_life_lost)
-                == episodic_life_terminations
+                == life_loss_terminations
             )
-            assert data_equivalence(standard_truncations, episodic_life_truncations)
-            assert data_equivalence(standard_info, episodic_life_info)
+            assert data_equivalence(standard_truncations, life_loss_truncations)
+            assert data_equivalence(standard_info, life_loss_info)
 
-        previous_lives = standard_info["lives"]
+            if not rollout_life_lost:
+                rollout_life_lost = life_loss_terminations.any()
 
-    assert rollout_life_lost, "No life lost in rollout"
+                (
+                    episodic_life_obs,
+                    episodic_life_rewards,
+                    episodic_life_terminations,
+                    episodic_life_truncations,
+                    episodic_life_info,
+                ) = episodic_life_envs.step(actions)
 
-    standard_envs.close()
-    episodic_life_envs.close()
-    life_loss_envs.close()
+                assert obs_equivalence(
+                    standard_obs, episodic_life_obs, i=i, episodic_life=True
+                )
+                assert data_equivalence(standard_rewards, episodic_life_rewards)
+                assert np.all(
+                    np.logical_or(standard_terminations, action_life_lost)
+                    == episodic_life_terminations
+                )
+                assert data_equivalence(standard_truncations, episodic_life_truncations)
+                assert data_equivalence(standard_info, episodic_life_info)
+
+            previous_lives = standard_info["lives"]
+
+        assert rollout_life_lost, "No life lost in rollout"
+
+        standard_envs.close()
+        episodic_life_envs.close()
+        life_loss_envs.close()

--- a/tests/python/test_atari_vector_env.py
+++ b/tests/python/test_atari_vector_env.py
@@ -420,9 +420,7 @@ class TestVectorEnv:
             [
                 lambda: gym.wrappers.FrameStackObservation(
                     gym.wrappers.AtariPreprocessing(
-                        gym.make(
-                            "BreakoutNoFrameskip-v4",
-                        ),
+                        gym.make(env_id, **self.disable_env_args),
                         terminal_on_life_loss=True,
                         **self.disable_preprocessing_args,
                     ),

--- a/tests/python/test_atari_vector_env.py
+++ b/tests/python/test_atari_vector_env.py
@@ -181,7 +181,7 @@ class TestVectorEnv:
             [
                 lambda: gym.wrappers.FrameStackObservation(
                     gym.wrappers.AtariPreprocessing(
-                        gym.make(env_id),
+                        gym.make(env_id, **self.disable_env_args),
                         frame_skip=frame_skip,
                         screen_size=(img_width, img_height),
                         grayscale_obs=grayscale,


### PR DESCRIPTION
Currently the vector environment testing is done with a single rom, Breakout, for speed as otherwise the testing would take hours. 
However, to make it easier to test if developers wish, the tests are now in a class that can be parametrized by all available ROMs. 

In doing this, bugs were found
* Fixes variable screen sizes for some environments
* Some environments have no lives causing `test_episodic_life_and_life_loss_info` to error