### PR TITLE
Optimise `StateBufferQueue` to use Semaphore not mutexes

### DIFF
--- a/tests/python/test_atari_vector_env.py
+++ b/tests/python/test_atari_vector_env.py
@@ -317,7 +317,7 @@ class TestVectorEnv:
         env_id,
         batch_size=4,
         num_envs=8,
-        rollout_length=100,
+        rollout_length=1000,
         reset_seed=123,
         action_seed=123,
     ):


### PR DESCRIPTION
This PR optimises the `StateBufferQueue` to allow multiple threads to write Timesteps at the same time while using Semaphore that are more efficient than mutexes. 

| num-envs | main steps per second | PR steps per second | 
| --- | --- | --- | 
| 16 | 11346 | 11272 |
| 64 | 15168 |  15044 |
| 128 | 17311 |  17349 |