### PR TITLE
Update to use Scikit build core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
             python: '3.12'
             triplet: x64-osx-mixed
 
+          - runs-on: macos-14
+            python: '3.12'
+            triplet: arm64-osx-mixed
+
           - runs-on: windows-latest
             python: '3.12'
             triplet: x64-windows

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,9 +74,3 @@ project(ale VERSION ${ALE_DEFAULT_VERSION}
 
 # Main ALE src directory
 add_subdirectory(src/ale)
-
-# Only include tests in the main project
-# if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-#  enable_testing()
-#  add_subdirectory(tests)
-# endif()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [build-system]
 requires = [
-    "setuptools>=77.0.0",
+    "scikit-build-core>=0.11.0",
     "jax >= 0.4.31; python_version > '3.9' and (sys_platform == 'win32' or sys_platform == 'linux')"
 ]
-build-backend = "setuptools.build_meta"
+build-backend = "scikit_build_core.build"
 
 [project]
 name = "ale-py"
@@ -64,6 +64,38 @@ test = [
 homepage = "https://github.com/Farama-Foundation/Arcade-Learning-Environment"
 documentation = "https://ale.farama.org"
 changelog = "https://github.com/Farama-Foundation/Arcade-Learning-Environment/blob/master/CHANGELOG.md"
+
+[tool.scikit-build]
+# Build directory
+build-dir = "build/{wheel_tag}"
+# Minimum CMake version
+cmake.minimum-version = "3.22"
+# CMake build type
+cmake.build-type = "Release"
+# Verbose output for debugging
+cmake.verbose = false
+# Install components
+install.components = ["python"]
+# Wheel configuration
+wheel.expand-macos-universal-tags = true
+# Source directory layout
+experimental = true
+
+[tool.scikit-build.cmake.define]
+# Core build options
+BUILD_CPP_LIB = "OFF"
+BUILD_PYTHON_LIB = "ON"
+BUILD_VECTOR_LIB = "ON"
+SDL_SUPPORT = "ON"
+SDL_DYNLOAD = "ON"
+# Python executable
+Python3_EXECUTABLE = { env = "PYTHON_EXECUTABLE", default = "" }
+
+#[tool.scikit-build.cmake.define.BUILD_VECTOR_XLA_LIB]
+## Only enable XLA on supported platforms
+#when = "python_version>='3.10' and (sys_platform=='win32' or sys_platform=='linux')"
+#value = "ON"
+#default = "OFF"
 
 [tool.setuptools]
 packages = [

--- a/setup.py
+++ b/setup.py
@@ -1,125 +1,7 @@
 """Setup file for ALE."""
 
 import os
-import platform
 import re
-import shutil
-import subprocess
-import sys
-
-from setuptools import Extension, setup
-from setuptools.command.build_ext import build_ext
-
-current_working_file = os.path.abspath(os.path.dirname(__file__))
-
-
-class CMakeExtension(Extension):
-    def __init__(self, name, sourcedir=""):
-        Extension.__init__(self, name, sources=[])
-        self.sourcedir = os.path.abspath(sourcedir)
-
-
-class CMakeBuild(build_ext):
-    PLAT_TO_CMAKE = {
-        "win32": "Win32",
-        "win-amd64": "x64",
-        "win-arm32": "ARM",
-        "win-arm64": "ARM64",
-    }
-
-    def build_extension(self, ext):
-        extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
-
-        # required for rpath detection of libraries
-        if not extdir.endswith(os.path.sep):
-            extdir += os.path.sep
-
-        config = "Debug" if self.debug else "Release"
-
-        # CMake lets you override the generator - we need to check this.
-        # Can be set with Conda-Build, for example.
-        cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
-
-        cmake_args = [
-            f"-DCMAKE_BUILD_TYPE={config}",
-            f"-DPython3_EXECUTABLE={sys.executable}",
-            f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}",
-            "-DSDL_SUPPORT=ON",
-            "-DSDL_DYNLOAD=ON",
-            "-DBUILD_CPP_LIB=OFF",
-            "-DBUILD_PYTHON_LIB=ON",
-            "-DBUILD_VECTOR_LIB=ON",
-        ]
-        # We can only support XLA on platforms with JAX support (e.g., 3.10+ and Windows/Linux)
-        if sys.version_info >= (3, 10) and platform.system() in {
-            "Windows",
-            "Linux",
-        }:
-            cmake_args.append("-DBUILD_VECTOR_XLA_LIB=ON")
-        build_args = []
-
-        if self.compiler.compiler_type != "msvc":
-            # Using Ninja-build since it a) is available as a wheel and b)
-            # multithreads automatically. MSVC would require all variables be
-            # exported for Ninja to pick it up, which is a little tricky to do.
-            # Users can override the generator with CMAKE_GENERATOR in CMake
-            # 3.15+.
-            if not cmake_generator or cmake_generator == "Ninja":
-                try:
-                    import ninja  # noqa: F401
-
-                    ninja_executable_path = os.path.join(ninja.BIN_DIR, "ninja")
-                    cmake_args += [
-                        "-GNinja",
-                        f"-DCMAKE_MAKE_PROGRAM:FILEPATH={ninja_executable_path}",
-                    ]
-                except ImportError:
-                    if shutil.which("ninja") is not None:
-                        cmake_args += [
-                            "-GNinja",
-                        ]
-
-        else:
-            # Single config generators are handled "normally"
-            single_config = any(x in cmake_generator for x in {"NMake", "Ninja"})
-
-            # CMake allows an arch-in-generator style for backward compatibility
-            contains_arch = any(x in cmake_generator for x in {"ARM", "Win64"})
-
-            # Specify the arch if using MSVC generator, but only if it doesn't
-            # contain a backward-compatibility arch spec already in the
-            # generator name.
-            if not single_config and not contains_arch:
-                cmake_args += ["-A", self.PLAT_TO_CMAKE[self.plat_name]]
-
-            # Multi-config generators have a different way to specify configs
-            if not single_config:
-                cmake_args += [
-                    f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{config.upper()}={extdir}"
-                ]
-                build_args += ["--config", config]
-
-        if sys.platform.startswith("darwin"):
-            # Cross-compile support for macOS - respect ARCHFLAGS if set
-            archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
-            if archs:
-                cmake_args += ["-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
-
-        # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level
-        # across all generators.
-        if "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:
-            # self.parallel is a Python 3 only way to set parallel jobs by hand
-            # using -j in the build_ext call, not supported by pip or PyPA-build.
-            if hasattr(self, "parallel") and self.parallel:
-                build_args += [f"-j{self.parallel}"]
-
-        build_temp = os.path.join(self.build_temp, ext.name)
-        if not os.path.exists(build_temp):
-            os.makedirs(build_temp)
-
-        subprocess.check_call(["cmake", ext.sourcedir] + cmake_args, cwd=build_temp)
-        subprocess.check_call(["cmake", "--build", "."] + build_args, cwd=build_temp)
-
 
 def parse_version(version_file):
     """Parse version from `version_file`.
@@ -129,9 +11,6 @@ def parse_version(version_file):
 
     If we're not running in CI we'll append the current git SHA to the
     version identifier.
-
-    raises AssertionError: If `${GITHUB_REF#/v/*/}` doesn't start with
-        the version specified in `version_file`.
     """
     semver_regex = r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
     semver_prog = re.compile(semver_regex)
@@ -142,28 +21,10 @@ def parse_version(version_file):
 
     return version
 
+def get_version():
+    """Get the version for the package."""
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    version_file = os.path.join(current_dir, "version.txt")
+    return parse_version(version_file)
 
-def get_setup_requires():
-    """Determine extra dependencies necessary for build"""
-    setup_requires = []
-    if shutil.which("cmake") is None:
-        setup_requires += ["cmake>=3.22"]
-    if shutil.which("ninja") is None:
-        setup_requires += [
-            "ninja; sys_platform != 'win32' and platform_machine != 'arm64'"
-        ]
-    return setup_requires
-
-
-if __name__ == "__main__":
-    # Allow for running `pip wheel` from other directories
-    current_working_file and os.chdir(current_working_file)
-    # Most config options are in `setup.cfg`. These are the
-    # only dynamic options we need at build time.
-    setup(
-        name="ale-py",
-        version=parse_version("version.txt"),
-        setup_requires=get_setup_requires(),
-        ext_modules=[CMakeExtension("ale_py._ale_py")],
-        cmdclass={"build_ext": CMakeBuild},
-    )
+__version__ = get_version()

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 import os
 import re
 
+
 def parse_version(version_file):
     """Parse version from `version_file`.
 
@@ -21,10 +22,12 @@ def parse_version(version_file):
 
     return version
 
+
 def get_version():
     """Get the version for the package."""
     current_dir = os.path.dirname(os.path.abspath(__file__))
     version_file = os.path.join(current_dir, "version.txt")
     return parse_version(version_file)
+
 
 __version__ = get_version()


### PR DESCRIPTION
The compile system used previously had an extremely complex setup.py that was difficult to maintain. 
[Scikit-build-core](https://scikit-build-core.readthedocs.io/en/latest/) provides a significantly easier cross compilation, etc support as can be seen by the changes