### PR TITLE
Add features x11 and wayland to sdl

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,7 +11,16 @@
       "dependencies": [
         {
           "name": "sdl2",
-          "features": [],
+          "features": [
+            {
+              "name": "x11",
+              "platform": "linux"
+            },
+            {
+              "name": "wayland",
+              "platform": "linux"
+            }
+          ],
           "default-features": false
         }
       ]


### PR DESCRIPTION
in commit fa48461, the sdl version was upgraded from `2.24.2` to `2.30.11` in vcpkg. From what I understood, in older versions even if you disable default features, SDL would be built with x11 anyways (?) however that changed since version `2.26.2` in vcpkg and not using default features resulted in neither building with x11 nor with wayland support, which results in having the no display issue. 

Here we explicitly specify to use features x11 and wayland, which fixes the issue. We don't enable default features as that includes `ibus` and `dbus` which aren't necessary and cause build issues anyways.

Fixes #625.
