### PR TITLE
Reject degenerate stochastic frameskip (n, n) at construction instead of crashing in step()

### DIFF
--- a/src/ale/python/env.py
+++ b/src/ale/python/env.py
@@ -102,13 +102,13 @@ class AtariEnv(gymnasium.Env, utils.EzPickle):
             raise error.Error(
                 f"Invalid stochastic frameskip length of {len(frameskip)}, expected length 2."
             )
-        elif isinstance(frameskip, tuple) and frameskip[0] > frameskip[1]:
+        elif isinstance(frameskip, tuple) and frameskip[0] >= frameskip[1]:
             raise error.Error(
-                "Invalid stochastic frameskip, lower bound is greater than upper bound."
+                "Invalid stochastic frameskip, lower bound must be strictly less than upper bound."
             )
         elif isinstance(frameskip, tuple) and frameskip[0] <= 0:
             raise error.Error(
-                "Invalid stochastic frameskip lower bound is greater than upper bound."
+                "Invalid stochastic frameskip, lower bound must be positive."
             )
 
         if render_mode is not None and render_mode not in {"rgb_array", "human"}:

--- a/tests/python/test_atari_env.py
+++ b/tests/python/test_atari_env.py
@@ -239,7 +239,9 @@ def test_gym_reset_with_infos(tetris_env):
     assert "frame_number" in info
 
 
-@pytest.mark.parametrize("frameskip", [0, -1, 4.0, (-1, 5), (0, 5), (5, 2), (1, 2, 3)])
+@pytest.mark.parametrize(
+    "frameskip", [0, -1, 4.0, (-1, 5), (0, 5), (5, 2), (4, 4), (1, 2, 3)]
+)
 def test_frameskip_warnings(tetris_rom_path, frameskip):
     with patch("ale_py.roms.Tetris", create=True, new_callable=lambda: tetris_rom_path):
         with pytest.raises(gymnasium.error.Error):


### PR DESCRIPTION
## What

Tighten the stochastic-frameskip validation in `AtariEnv.__init__` so a degenerate equal-bounds tuple such as `(4, 4)` is rejected at construction, and fix a copy-paste error in one of the validation messages.

## Why

The validation only rejected reversed bounds (`frameskip[0] > frameskip[1]`), so an equal-bounds tuple like `(4, 4)` passed. At step time, `step()` calls `self.np_random.integers(*self._frameskip)`, and numpy's `integers()` samples from the half-open interval `[low, high)`. With `low == high` that range is empty and raises `ValueError: low >= high`.

The upshot is that `AtariEnv("Pong", frameskip=(4, 4))` and `reset()` succeed, then the very first `step()` dies with a cryptic numpy error that doesn't obviously point back to the frameskip argument the user passed.

Changing the comparison to `>=` makes the invalid (empty) range fail fast at construction, consistent with the half-open sampling used in `step()`. I also fixed the message on the `frameskip[0] <= 0` branch, which duplicated the bound-ordering text instead of describing the positive-lower-bound requirement.

## Testing

Added the degenerate `(4, 4)` case to the existing `test_frameskip_warnings` parametrization, which asserts that construction raises `gymnasium.error.Error`. The new case fails before this change (construction proceeds past validation) and passes after it.

```
python -m pytest tests/python/test_atari_env.py::test_frameskip_warnings -q
8 passed
```
