### PR TITLE
Fix VectorEnv partial resets

### DIFF
--- a/src/ale/python/vector_env.py
+++ b/src/ale/python/vector_env.py
@@ -154,8 +154,13 @@ class AtariVectorEnv(VectorEnv):
         """Resets the sub-environments.
 
         Args:
-            seed: Current unimplemented
-            options: Supports `reset_mask` that indicates what sub-environments should be reset
+            seed: The seed for the sub-environments being reset. An integer seeds them with
+                consecutive values starting at `seed`; an array provides one seed per
+                sub-environment being reset.
+            options: Supports `reset_mask`, a boolean array of shape `(num_envs,)` selecting
+                which sub-environments to reset. Sub-environments that are masked out are
+                left untouched and report their current observation and info. Partial resets
+                require `batch_size == num_envs` and a preceding full reset.
 
         Returns:
             Tuple of observations for the sub-environments and info on them.
@@ -164,7 +169,15 @@ class AtariVectorEnv(VectorEnv):
             reset_indices = np.arange(self.num_envs)
         else:
             reset_mask = options["reset_mask"]
-            assert isinstance(reset_mask, np.ndarray) and reset_mask.dtype == np.bool_
+            if not isinstance(reset_mask, np.ndarray) or reset_mask.dtype != np.bool_:
+                raise TypeError(
+                    f"`reset_mask` must be a boolean numpy array, got {type(reset_mask)} "
+                    f"with dtype {getattr(reset_mask, 'dtype', None)}"
+                )
+            if reset_mask.shape != (self.num_envs,):
+                raise ValueError(
+                    f"`reset_mask` must have shape {(self.num_envs,)}, got {reset_mask.shape}"
+                )
             (reset_indices,) = np.where(reset_mask)
 
         if seed is None:
@@ -172,6 +185,11 @@ class AtariVectorEnv(VectorEnv):
         elif isinstance(seed, int):
             reset_seeds = np.arange(seed, seed + len(reset_indices))
         elif isinstance(seed, np.ndarray):
+            if seed.shape != (len(reset_indices),):
+                raise ValueError(
+                    f"`seed` must have one entry per sub-environment being reset, expected "
+                    f"shape {(len(reset_indices),)}, got {seed.shape}"
+                )
             reset_seeds = seed
         else:
             raise TypeError("Unsupported seed type")
@@ -312,8 +330,8 @@ class AtariVectorEnv(VectorEnv):
                 )
             else:
                 reset_seeds = jnp.asarray(seed, dtype=jnp.int32)
-
-            chex.assert_shape(reset_seeds, (self.num_envs,))
+            # One seed per sub-environment being reset
+            chex.assert_shape(reset_seeds, (len(reset_indices),))
 
             new_handle, obs, env_ids, lives, frame_numbers, episode_frame_numbers = (
                 xla_call(handle, reset_indices, reset_seeds)

--- a/src/ale/vector/env_vectorizer.cpp
+++ b/src/ale/vector/env_vectorizer.cpp
@@ -115,6 +115,40 @@ BatchResult EnvVectorizer::reset(const std::vector<int>& env_ids, const std::vec
         throw std::invalid_argument("env_ids and seeds must have same size");
     }
 
+    // Mark which environments are being reset, rejecting out-of-range and duplicate ids.
+    std::vector<bool> is_reset(num_envs_, false);
+    for (const int env_id : env_ids) {
+        if (env_id < 0 || env_id >= num_envs_) {
+            throw std::out_of_range(
+                "reset env_id " + std::to_string(env_id) + " is out of range [0, " + std::to_string(num_envs_) + ")"
+            );
+        }
+        if (is_reset[env_id]) {
+            throw std::invalid_argument("reset has a duplicate env_id=" + std::to_string(env_id));
+        }
+        is_reset[env_id] = true;
+    }
+
+    const bool partial = env_ids.size() != static_cast<std::size_t>(num_envs_);
+    if (partial) {
+        // Environments that have never been reset have no observation to report.
+        if (first_batch_) {
+            throw std::runtime_error(
+                "The first reset() must reset every environment (got " +
+                std::to_string(env_ids.size()) + " of " + std::to_string(num_envs_) + ")"
+            );
+        }
+
+        // For partial resets, this only works for sync mode (not async mode)
+        if (batch_size_ != num_envs_) {
+            throw std::invalid_argument(
+                "Partial reset is not supported for async mode where batch_size < num_envs (got batch_size=" +
+                std::to_string(batch_size_) + ", num_envs=" + std::to_string(num_envs_) + ")"
+            );
+        }
+
+    }
+
     first_batch_ = false;
 
     // Set seeds and prepare actions
@@ -134,6 +168,18 @@ BatchResult EnvVectorizer::reset(const std::vector<int>& env_ids, const std::vec
 
     // Enqueue reset actions
     action_queue_->enqueue_bulk(actions);
+
+    // For partial resets, the environments not reset, we can stage their observations using the previous values
+    if (partial) {
+        for (int env_id = 0; env_id < num_envs_; ++env_id) {
+            if (!is_reset[env_id]) {
+                const auto& env = *envs_[env_id];
+                staging_->stage_result(env_id, [&env](OutputSlot& slot) {
+                    env.write_to(slot);
+                });
+            }
+        }
+    }
 
     // Wait for results
     return recv();

--- a/src/ale/vector/env_vectorizer.hpp
+++ b/src/ale/vector/env_vectorizer.hpp
@@ -51,7 +51,12 @@ public:
     EnvVectorizer& operator=(const EnvVectorizer&) = delete;
 
     /// Reset specified environments with given seeds.
-    /// @param env_ids Environment indices to reset
+    ///
+    /// A partial reset (env_ids smaller than num_envs) requires batch_size == num_envs and
+    /// a preceding full reset. Environments left out of env_ids are not stepped; the batch
+    /// simply reports their current state alongside the freshly reset ones.
+    ///
+    /// @param env_ids Environment indices to reset, unique and within [0, num_envs)
     /// @param seeds Seeds for each environment (-1 to keep current seed)
     /// @return Batch of results from batch_size environments
     BatchResult reset(const std::vector<int>& env_ids, const std::vector<int>& seeds);

--- a/tests/python/test_atari_vector_env.py
+++ b/tests/python/test_atari_vector_env.py
@@ -440,6 +440,94 @@ class TestVectorEnv:
         sync_envs.close()
         async_envs.close()
 
+    @pytest.mark.parametrize(
+        "mask",
+        [
+            [True, False, False, False],
+            [False, True, False, True],
+            [False, False, False, False],
+            [True, True, True, True],
+        ],
+        ids=["single", "multiple", "none", "all"],
+    )
+    def test_reset_mask_options(self, env_id, mask, num_envs=4, reset_seed=123):
+        """Sub-environments selected by `reset_mask` are reset, the rest are left untouched.
+
+        Regression test for a deadlock when fewer than `batch_size` envs were reset
+        (Farama-Foundation/Arcade-Learning-Environment#673 and #676).
+        """
+        mask = np.array(mask)
+        envs = gym.make_vec(env_id, num_envs, **self.disable_vector_args)
+
+        initial_obs, _ = envs.reset(seed=reset_seed)
+        for _ in range(20):
+            obs, _, _, _, info = envs.step(np.ones(num_envs, dtype=np.int32))
+
+        pre_obs = obs.copy()
+        pre_frame_number = info["episode_frame_number"].copy()
+
+        # reset with mask
+        reset_mask_obs, info = envs.reset(seed=reset_seed, options={"reset_mask": mask})
+
+        assert reset_mask_obs.shape == (num_envs, 4, 84, 84)
+        assert np.all(info["env_id"] == np.arange(num_envs))
+
+        # Reset envs return the same observation as a full reset with the same seed
+        assert data_equivalence(reset_mask_obs[mask], initial_obs[mask])
+        # Unmasked envs are untouched, both observation and info
+        assert data_equivalence(reset_mask_obs[~mask], pre_obs[~mask])
+        assert data_equivalence(
+            info["episode_frame_number"][mask],
+            np.zeros((num_envs,), dtype=np.int32)[mask],
+        )
+        assert data_equivalence(
+            info["episode_frame_number"][~mask], pre_frame_number[~mask]
+        )
+
+        # Actions still route to the environment they were reported for
+        _, _, _, _, info = envs.step(np.ones(num_envs, dtype=np.int32))
+        assert np.all(info["env_id"] == np.arange(num_envs))
+        assert data_equivalence(
+            info["episode_frame_number"][~mask], pre_frame_number[~mask] + 4
+        )
+        assert data_equivalence(
+            info["episode_frame_number"][mask],
+            np.full((num_envs,), 4, dtype=np.int32)[mask],
+        )
+
+        envs.close()
+
+    def test_invalid_reset_masks(self, env_id, num_envs=4):
+        """Invalid `reset_mask` usage raises rather than hanging or silently misbehaving."""
+        partial_mask = np.array([True] + [False] * (num_envs - 1))
+
+        # Partial resets need a full batch to fall back on for the untouched envs
+        async_envs = gym.make_vec(env_id, num_envs, batch_size=num_envs // 2)
+        async_envs.reset()
+        with pytest.raises(ValueError, match="batch_size < num_envs"):
+            async_envs.reset(options={"reset_mask": partial_mask})
+        async_envs.close()
+
+        # Envs that have never been reset have no observation to report
+        envs = gym.make_vec(env_id, num_envs, **self.disable_vector_args)
+        with pytest.raises(RuntimeError, match="first reset\\(\\) must reset every"):
+            envs.reset(options={"reset_mask": partial_mask})
+
+        envs.reset()
+        with pytest.raises(TypeError, match="must be a boolean numpy array"):
+            envs.reset(options={"reset_mask": np.array([1, 0, 0, 0])})
+        with pytest.raises(ValueError, match="must have shape"):
+            envs.reset(options={"reset_mask": np.array([True, False])})
+        with pytest.raises(ValueError, match="one entry per sub-environment"):
+            envs.reset(seed=np.array([1, 2]), options={"reset_mask": partial_mask})
+
+        with pytest.raises(ValueError, match="duplicate env_id"):
+            envs.ale.reset([0, 0], [-1, -1])
+        with pytest.raises(IndexError, match="out of range"):
+            envs.ale.reset([num_envs], [-1])
+
+        envs.close()
+
     def test_episodic_life_equivalence(self, env_id, num_envs=8):
         gym_envs = gym.vector.SyncVectorEnv(
             [


### PR DESCRIPTION
https://github.com/Farama-Foundation/Arcade-Learning-Environment/issues/673 and https://github.com/Farama-Foundation/Arcade-Learning-Environment/issues/676 noted two issues with the vectorizer's partial resets. 
This PR fixes those issues through raising errors early before a hang might occur or fix the issue with tests to check the implementations