### PR TITLE
Potential fix for code scanning alert no. 23: Multiplication result converted to larger type

### DIFF
--- a/src/ale/vector/preprocessed_env.hpp
+++ b/src/ale/vector/preprocessed_env.hpp
@@ -82,7 +82,9 @@ public:
     const ActionVect& action_set() const { return action_set_; }
 
     /// Get stacked observation size in bytes
-    std::size_t stacked_obs_size() const { return obs_size_ * stack_num_; }
+    std::size_t stacked_obs_size() const {
+        return static_cast<std::size_t>(obs_size_) * static_cast<std::size_t>(stack_num_);
+    }
 
     /// Get channels per frame (1 for grayscale, 3 for RGB)
     int channels_per_frame() const { return channels_per_frame_; }


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/23](https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/23)

Use an explicit cast on one operand so the multiplication is performed in `std::size_t` rather than `int`.

Best minimal fix (without changing behavior): in `src/ale/vector/preprocessed_env.hpp`, update `stacked_obs_size()` so `obs_size_` (or `stack_num_`) is cast to `std::size_t` before multiplication:
- from: `return obs_size_ * stack_num_;`
- to: `return static_cast<std::size_t>(obs_size_) * static_cast<std::size_t>(stack_num_);`

No new imports or helper methods are needed since `std::size_t` is already in use in the same class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
