### PR TITLE
Potential fix for code scanning alert no. 16: Multiplication result converted to larger type

### DIFF
--- a/src/ale/common/ScreenExporter.cpp
+++ b/src/ale/common/ScreenExporter.cpp
@@ -132,7 +132,8 @@ static void writePNGData(std::ofstream& out, const ALEScreen& screen,
   std::vector<uint8_t> compmem(compmemsize, 0);
 
   if ((compress(&compmem[0], &compmemsize, &buffer[0],
-                height * (width * 3 + 1)) != Z_OK)) {
+                static_cast<uLongf>(height) *
+                    (static_cast<uLongf>(width) * 3 + 1)) != Z_OK)) {
     // @todo -- throw a proper exception
     Logger::Error << "Error: Couldn't compress PNG\n";
     return;


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/16](https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/16)

To fix this safely, ensure the multiplication is performed in a wider type **before** the multiply occurs. The best minimal change is to cast one multiplicand to `uLongf` (or `uLong`) so the whole expression is evaluated in the wider type used by zlib lengths.

In `src/ale/common/ScreenExporter.cpp`, update the `compress` call (around lines 134–135) so the source length argument is computed as `uLongf` arithmetic, e.g. `static_cast<uLongf>(height) * (static_cast<uLongf>(width) * 3 + 1)`. This preserves functionality while removing overflow risk in intermediate `int` math. No new methods/imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
