### PR TITLE
Potential fix for code scanning alert no. 21: Multiplication result converted to larger type

### DIFF
--- a/src/ale/wasm/ale_wasm_interface.cpp
+++ b/src/ale/wasm/ale_wasm_interface.cpp
@@ -148,7 +148,9 @@ public:
         const int height = ale.getScreen().height();
 
         // Convert RGB to RGBA format
-        std::vector<unsigned char> rgba_buffer(width * height * 4);
+        std::vector<unsigned char> rgba_buffer(
+            static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * 4u
+        );
         for (int i = 0; i < width * height; i++) {
             rgba_buffer[i * 4] = screen_buffer[i * 3];       // R
             rgba_buffer[i * 4 + 1] = screen_buffer[i * 3 + 1]; // G


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/21](https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/21)

The fix is to ensure multiplication is performed in a sufficiently wide unsigned type (`std::size_t`) *before* any overflow-prone `int` intermediate is formed.

Best minimal fix in `src/ale/wasm/ale_wasm_interface.cpp`:
- In `getScreenImageData()`, change vector size construction from:
  - `std::vector<unsigned char> rgba_buffer(width * height * 4);`
- To:
  - `std::vector<unsigned char> rgba_buffer(static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * 4u);`

This preserves functionality while removing the overflow-prone `int` multiplication pattern. No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
