### PR TITLE
Potential fix for code scanning alert no. 19: Multiplication result converted to larger type

### DIFF
--- a/src/ale/environment/ale_screen.hpp
+++ b/src/ale/environment/ale_screen.hpp
@@ -66,7 +66,8 @@ class ALEScreen {
 inline ALEScreen::ALEScreen(int h, int w)
     : m_rows(h), m_columns(w),
       // Create a pixel array of the requisite size
-      m_pixels(m_rows * m_columns) {}
+      m_pixels(static_cast<std::size_t>(m_rows) *
+               static_cast<std::size_t>(m_columns)) {}
 
 inline ALEScreen::ALEScreen(const ALEScreen& rhs)
     : m_rows(rhs.m_rows), m_columns(rhs.m_columns), m_pixels(rhs.m_pixels) {}


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/19](https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/19)

The fix is to force multiplication to occur in an unsigned wider type used for container sizes (`std::size_t`) before the multiply, not after.  
Best minimal fix: in `src/ale/environment/ale_screen.hpp`, update the constructor initializer for `m_pixels` so at least one multiplicand is cast to `std::size_t`:

- Change `m_pixels(m_rows * m_columns)`  
- To `m_pixels(static_cast<std::size_t>(m_rows) * static_cast<std::size_t>(m_columns))`

This preserves behavior for valid non-negative dimensions while preventing intermediate `int` overflow. No new methods or dependencies are needed; `<cstddef>` is already included, so `std::size_t` is available.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
