### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -20,6 +20,9 @@ on:
     branches:
       - "*"
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/24](https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/24)

Add an explicit `permissions` block at the workflow root in `.github/workflows/build-python.yml`, immediately after the `on:` section (before `jobs:`), so all jobs inherit least-privilege defaults unless overridden later.

Best minimal safe fix (without changing intended behavior) is:

- `contents: read`

This satisfies checkout/read operations and addresses CodeQL’s recommendation. If any specific job later needs writes (e.g., releases, PR comments), add a **job-level** `permissions` override only for that job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
