### PR TITLE
Reject non-positive frameskip in AtariVectorEnv

### DIFF
--- a/src/ale/python/vector_env.py
+++ b/src/ale/python/vector_env.py
@@ -9,6 +9,7 @@ import gymnasium.vector.utils
 import numpy as np
 from ale_py import roms
 from ale_py.env import AtariEnv
+from gymnasium import error
 from gymnasium.core import ObsType
 from gymnasium.spaces import Box, Discrete
 from gymnasium.vector import AutoresetMode, VectorEnv
@@ -70,6 +71,13 @@ class AtariVectorEnv(VectorEnv):
             reward_clipping: If to clip rewards between -1 and 1
             use_fire_reset: If to take fire action on reset if available
         """
+        if type(frameskip) is not int:
+            raise error.Error(f"Invalid frameskip type: {type(frameskip)}.")
+        if isinstance(frameskip, int) and frameskip <= 0:
+            raise error.Error(
+                f"Invalid frameskip of {frameskip}, frameskip must be positive."
+            )
+
         rom_path = roms.get_rom_path(game)
         assert (
             rom_path is not None

--- a/tests/python/test_atari_vector_env.py
+++ b/tests/python/test_atari_vector_env.py
@@ -497,6 +497,12 @@ class TestVectorEnv:
 
         envs.close()
 
+    @pytest.mark.parametrize("frameskip", [0, -1, 4.0])
+    def test_invalid_frameskip(self, env_id, frameskip):
+        """Invalid frameskip values are rejected at construction, matching AtariEnv."""
+        with pytest.raises(gym.error.Error, match="frameskip"):
+            gym.make_vec(env_id, num_envs=1, frameskip=frameskip)
+
     def test_invalid_reset_masks(self, env_id, num_envs=4):
         """Invalid `reset_mask` usage raises rather than hanging or silently misbehaving."""
         partial_mask = np.array([True] + [False] * (num_envs - 1))


### PR DESCRIPTION
`AtariEnv` rejects `frameskip <= 0` at construction. `AtariVectorEnv` never did, and the C++ skip loop is `for (skip_id = frame_skip_; skip_id > 0; --skip_id)`, so `frameskip=0` (and `-1`) constructs and then never advances the emulator.

    AtariVectorEnv("pong", num_envs=1, frameskip=0)  # used to succeed

Same check as `AtariEnv`: non-int type, or a non-positive int, raises `gymnasium.error.Error`.

`pytest tests/python/test_atari_vector_env.py::TestVectorEnv::test_invalid_frameskip` and `test_frameskip_warnings` on `AtariEnv` both pass.

Related to the same class of constructor check as #710.
