### PR TITLE
Add doc pages for notable Atari environment sets

### DIFF
--- a/docs/environment-sets.md
+++ b/docs/environment-sets.md
@@ -1,0 +1,20 @@
+---
+firstpage:
+lastpage:
+---
+
+# Environment Sets
+
+Research papers rarely benchmark on all of the games the ALE supports, several well-known subsets are used instead.
+The pages below list the games belonging to each notable set:
+
+- [Complete list](environments/complete_list) — all 104 games supported by the ALE.
+- [Atari 57](environments/atari_57) — the 57 games used by DeepMind to benchmark agents, from DQN through Agent57.
+- [Previously in OpenAI Gym](environments/gym) — the 62 games that were registered in OpenAI Gym.
+
+```{toctree}
+:hidden:
+environments/complete_list
+environments/atari_57
+environments/gym
+```

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -7,9 +7,6 @@ lastpage:
 
 ```{toctree}
 :hidden:
-environments/complete_list
-environments/atari_57
-environments/gym
 environments/adventure
 environments/air_raid
 environments/alien
@@ -127,7 +124,7 @@ The pages below list the games belonging to each notable set:
 
 - [Complete list](environments/complete_list) — all 104 games supported by the ALE.
 - [Atari 57](environments/atari_57) — the 57 games used by DeepMind to benchmark agents, from DQN through Agent57.
-- [Environments previously in Gym](environments/gym) — the 62 games that were registered in OpenAI Gym.
+- [Previously in OpenAI Gym](environments/gym) — the 62 games that were registered in OpenAI Gym.
 
 ## Action Space
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -7,6 +7,9 @@ lastpage:
 
 ```{toctree}
 :hidden:
+environments/complete_list
+environments/atari_57
+environments/gym
 environments/adventure
 environments/air_raid
 environments/alien
@@ -116,6 +119,15 @@ environments/zaxxon
 ```{raw} html
    :file: environments/list.html
 ```
+
+## Environment sets
+
+Research papers rarely benchmark on all of the games the ALE supports, several well-known subsets are used instead.
+The pages below list the games belonging to each notable set:
+
+- [Complete list](environments/complete_list) — all 104 games supported by the ALE.
+- [Atari 57](environments/atari_57) — the 57 games used by DeepMind to benchmark agents, from DQN through Agent57.
+- [Environments previously in Gym](environments/gym) — the 62 games that were registered in OpenAI Gym.
 
 ## Action Space
 

--- a/docs/environments/atari_57.html
+++ b/docs/environments/atari_57.html
@@ -1,0 +1,686 @@
+<div class="env-grid">
+
+    <a href="../alien">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/alien.gif">
+            </div>
+            <div class="cell__title">
+                <span>Alien</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../amidar">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/amidar.gif">
+            </div>
+            <div class="cell__title">
+                <span>Amidar</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../assault">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/assault.gif">
+            </div>
+            <div class="cell__title">
+                <span>Assault</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../asterix">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/asterix.gif">
+            </div>
+            <div class="cell__title">
+                <span>Asterix</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../asteroids">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/asteroids.gif">
+            </div>
+            <div class="cell__title">
+                <span>Asteroids</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../atlantis">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/atlantis.gif">
+            </div>
+            <div class="cell__title">
+                <span>Atlantis</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../bank_heist">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/bank_heist.gif">
+            </div>
+            <div class="cell__title">
+                <span>Bank Heist</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../battle_zone">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/battle_zone.gif">
+            </div>
+            <div class="cell__title">
+                <span>Battle Zone</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../beam_rider">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/beam_rider.gif">
+            </div>
+            <div class="cell__title">
+                <span>Beam Rider</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../berzerk">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/berzerk.gif">
+            </div>
+            <div class="cell__title">
+                <span>Berzerk</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../bowling">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/bowling.gif">
+            </div>
+            <div class="cell__title">
+                <span>Bowling</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../boxing">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/boxing.gif">
+            </div>
+            <div class="cell__title">
+                <span>Boxing</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../breakout">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/breakout.gif">
+            </div>
+            <div class="cell__title">
+                <span>Breakout</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../centipede">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/centipede.gif">
+            </div>
+            <div class="cell__title">
+                <span>Centipede</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../chopper_command">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/chopper_command.gif">
+            </div>
+            <div class="cell__title">
+                <span>Chopper Command</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../crazy_climber">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/crazy_climber.gif">
+            </div>
+            <div class="cell__title">
+                <span>Crazy Climber</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../defender">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/defender.gif">
+            </div>
+            <div class="cell__title">
+                <span>Defender</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../demon_attack">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/demon_attack.gif">
+            </div>
+            <div class="cell__title">
+                <span>Demon Attack</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../double_dunk">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/double_dunk.gif">
+            </div>
+            <div class="cell__title">
+                <span>Double Dunk</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../enduro">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/enduro.gif">
+            </div>
+            <div class="cell__title">
+                <span>Enduro</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../fishing_derby">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/fishing_derby.gif">
+            </div>
+            <div class="cell__title">
+                <span>Fishing Derby</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../freeway">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/freeway.gif">
+            </div>
+            <div class="cell__title">
+                <span>Freeway</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../frostbite">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/frostbite.gif">
+            </div>
+            <div class="cell__title">
+                <span>Frostbite</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../gopher">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/gopher.gif">
+            </div>
+            <div class="cell__title">
+                <span>Gopher</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../gravitar">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/gravitar.gif">
+            </div>
+            <div class="cell__title">
+                <span>Gravitar</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../hero">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/hero.gif">
+            </div>
+            <div class="cell__title">
+                <span>Hero</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../ice_hockey">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/ice_hockey.gif">
+            </div>
+            <div class="cell__title">
+                <span>Ice Hockey</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../jamesbond">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/jamesbond.gif">
+            </div>
+            <div class="cell__title">
+                <span>Jamesbond</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../kangaroo">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/kangaroo.gif">
+            </div>
+            <div class="cell__title">
+                <span>Kangaroo</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../krull">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/krull.gif">
+            </div>
+            <div class="cell__title">
+                <span>Krull</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../kung_fu_master">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/kung_fu_master.gif">
+            </div>
+            <div class="cell__title">
+                <span>Kung Fu Master</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../montezuma_revenge">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/montezuma_revenge.gif">
+            </div>
+            <div class="cell__title">
+                <span>Montezuma Revenge</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../ms_pacman">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/ms_pacman.gif">
+            </div>
+            <div class="cell__title">
+                <span>Ms Pacman</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../name_this_game">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/name_this_game.gif">
+            </div>
+            <div class="cell__title">
+                <span>Name This Game</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../phoenix">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/phoenix.gif">
+            </div>
+            <div class="cell__title">
+                <span>Phoenix</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../pitfall">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/pitfall.gif">
+            </div>
+            <div class="cell__title">
+                <span>Pitfall</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../pong">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/pong.gif">
+            </div>
+            <div class="cell__title">
+                <span>Pong</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../private_eye">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/private_eye.gif">
+            </div>
+            <div class="cell__title">
+                <span>Private Eye</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../qbert">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/qbert.gif">
+            </div>
+            <div class="cell__title">
+                <span>Qbert</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../riverraid">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/riverraid.gif">
+            </div>
+            <div class="cell__title">
+                <span>Riverraid</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../road_runner">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/road_runner.gif">
+            </div>
+            <div class="cell__title">
+                <span>Road Runner</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../robotank">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/robotank.gif">
+            </div>
+            <div class="cell__title">
+                <span>Robotank</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../seaquest">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/seaquest.gif">
+            </div>
+            <div class="cell__title">
+                <span>Seaquest</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../skiing">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/skiing.gif">
+            </div>
+            <div class="cell__title">
+                <span>Skiing</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../solaris">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/solaris.gif">
+            </div>
+            <div class="cell__title">
+                <span>Solaris</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../space_invaders">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/space_invaders.gif">
+            </div>
+            <div class="cell__title">
+                <span>Space Invaders</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../star_gunner">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/star_gunner.gif">
+            </div>
+            <div class="cell__title">
+                <span>Star Gunner</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../surround">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/surround.gif">
+            </div>
+            <div class="cell__title">
+                <span>Surround</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../tennis">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/tennis.gif">
+            </div>
+            <div class="cell__title">
+                <span>Tennis</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../time_pilot">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/time_pilot.gif">
+            </div>
+            <div class="cell__title">
+                <span>Time Pilot</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../tutankham">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/tutankham.gif">
+            </div>
+            <div class="cell__title">
+                <span>Tutankham</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../up_n_down">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/up_n_down.gif">
+            </div>
+            <div class="cell__title">
+                <span>Up N Down</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../venture">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/venture.gif">
+            </div>
+            <div class="cell__title">
+                <span>Venture</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../video_pinball">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/video_pinball.gif">
+            </div>
+            <div class="cell__title">
+                <span>Video Pinball</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../wizard_of_wor">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/wizard_of_wor.gif">
+            </div>
+            <div class="cell__title">
+                <span>Wizard Of Wor</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../yars_revenge">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/yars_revenge.gif">
+            </div>
+            <div class="cell__title">
+                <span>Yars Revenge</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../zaxxon">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/zaxxon.gif">
+            </div>
+            <div class="cell__title">
+                <span>Zaxxon</span>
+            </div>
+        </div>
+    </a>
+
+</div>

--- a/docs/environments/atari_57.md
+++ b/docs/environments/atari_57.md
@@ -2,7 +2,7 @@
 
 The "Atari 57" set contains the 57 games used by DeepMind to benchmark agents, from DQN [[1]](#ref1) through Rainbow, R2D2, MuZero and Agent57 [[2]](#ref2). Reported "median" or "mean human-normalized scores" for Atari usually refer to this set of games.
 
-All 57 games are supported by the ALE. Note that `Defender` and `Surround` were historically unavailable in some ALE-based toolkits (e.g., `atari-py` used by early versions of OpenAI Gym), so some papers benchmark on only 55 of these games. For the games previously available in OpenAI Gym, see [Environments previously in Gym](gym).
+All 57 games are supported by the ALE. Note that `Defender` and `Surround` were historically unavailable in some ALE-based toolkits (e.g., `atari-py` used by early versions of OpenAI Gym), so some papers benchmark on only 55 of these games. For the games previously available in OpenAI Gym, see [Previously in OpenAI Gym](gym).
 
 ```{raw} html
 :file: atari_57.html

--- a/docs/environments/atari_57.md
+++ b/docs/environments/atari_57.md
@@ -1,0 +1,25 @@
+# Atari 57
+
+The "Atari 57" set contains the 57 games used by DeepMind to benchmark agents, from DQN [[1]](#ref1) through Rainbow, R2D2, MuZero and Agent57 [[2]](#ref2). Reported "median" or "mean human-normalized scores" for Atari usually refer to this set of games.
+
+All 57 games are supported by the ALE. Note that `Defender` and `Surround` were historically unavailable in some ALE-based toolkits (e.g., `atari-py` used by early versions of OpenAI Gym), so some papers benchmark on only 55 of these games. For the games previously available in OpenAI Gym, see [Environments previously in Gym](gym).
+
+```{raw} html
+:file: atari_57.html
+```
+
+## References
+
+(ref1)=
+<a id="ref1">[1]</a>
+Mnih et al.
+"Human-level control through deep reinforcement learning"
+Nature (2015)
+URL: https://www.nature.com/articles/nature14236
+
+(ref2)=
+<a id="ref2">[2]</a>
+Badia et al.
+"Agent57: Outperforming the Atari Human Benchmark"
+International Conference on Machine Learning (2020)
+URL: https://arxiv.org/abs/2003.13350

--- a/docs/environments/complete_list.md
+++ b/docs/environments/complete_list.md
@@ -1,6 +1,6 @@
 # Complete List - Atari
 
-All 104 games supported by the ALE are listed below. For the notable subsets of games commonly used to benchmark agents in research, see [Atari 57](atari_57) and [Environments previously in Gym](gym).
+All 104 games supported by the ALE are listed below. For the notable subsets of games commonly used to benchmark agents in research, see [Atari 57](atari_57) and [Previously in OpenAI Gym](gym).
 
 ```{raw} html
 :file: complete_list.html

--- a/docs/environments/complete_list.md
+++ b/docs/environments/complete_list.md
@@ -1,5 +1,7 @@
 # Complete List - Atari
 
+All 104 games supported by the ALE are listed below. For the notable subsets of games commonly used to benchmark agents in research, see [Atari 57](atari_57) and [Environments previously in Gym](gym).
+
 ```{raw} html
 :file: complete_list.html
 ```

--- a/docs/environments/gym.html
+++ b/docs/environments/gym.html
@@ -1,0 +1,746 @@
+<div class="env-grid">
+
+    <a href="../adventure">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/adventure.gif">
+            </div>
+            <div class="cell__title">
+                <span>Adventure</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../air_raid">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/air_raid.gif">
+            </div>
+            <div class="cell__title">
+                <span>Air Raid</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../alien">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/alien.gif">
+            </div>
+            <div class="cell__title">
+                <span>Alien</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../amidar">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/amidar.gif">
+            </div>
+            <div class="cell__title">
+                <span>Amidar</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../assault">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/assault.gif">
+            </div>
+            <div class="cell__title">
+                <span>Assault</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../asterix">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/asterix.gif">
+            </div>
+            <div class="cell__title">
+                <span>Asterix</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../asteroids">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/asteroids.gif">
+            </div>
+            <div class="cell__title">
+                <span>Asteroids</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../atlantis">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/atlantis.gif">
+            </div>
+            <div class="cell__title">
+                <span>Atlantis</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../bank_heist">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/bank_heist.gif">
+            </div>
+            <div class="cell__title">
+                <span>Bank Heist</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../battle_zone">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/battle_zone.gif">
+            </div>
+            <div class="cell__title">
+                <span>Battle Zone</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../beam_rider">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/beam_rider.gif">
+            </div>
+            <div class="cell__title">
+                <span>Beam Rider</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../berzerk">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/berzerk.gif">
+            </div>
+            <div class="cell__title">
+                <span>Berzerk</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../bowling">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/bowling.gif">
+            </div>
+            <div class="cell__title">
+                <span>Bowling</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../boxing">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/boxing.gif">
+            </div>
+            <div class="cell__title">
+                <span>Boxing</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../breakout">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/breakout.gif">
+            </div>
+            <div class="cell__title">
+                <span>Breakout</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../carnival">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/carnival.gif">
+            </div>
+            <div class="cell__title">
+                <span>Carnival</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../centipede">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/centipede.gif">
+            </div>
+            <div class="cell__title">
+                <span>Centipede</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../chopper_command">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/chopper_command.gif">
+            </div>
+            <div class="cell__title">
+                <span>Chopper Command</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../crazy_climber">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/crazy_climber.gif">
+            </div>
+            <div class="cell__title">
+                <span>Crazy Climber</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../defender">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/defender.gif">
+            </div>
+            <div class="cell__title">
+                <span>Defender</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../demon_attack">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/demon_attack.gif">
+            </div>
+            <div class="cell__title">
+                <span>Demon Attack</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../double_dunk">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/double_dunk.gif">
+            </div>
+            <div class="cell__title">
+                <span>Double Dunk</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../elevator_action">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/elevator_action.gif">
+            </div>
+            <div class="cell__title">
+                <span>Elevator Action</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../enduro">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/enduro.gif">
+            </div>
+            <div class="cell__title">
+                <span>Enduro</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../fishing_derby">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/fishing_derby.gif">
+            </div>
+            <div class="cell__title">
+                <span>Fishing Derby</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../freeway">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/freeway.gif">
+            </div>
+            <div class="cell__title">
+                <span>Freeway</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../frostbite">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/frostbite.gif">
+            </div>
+            <div class="cell__title">
+                <span>Frostbite</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../gopher">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/gopher.gif">
+            </div>
+            <div class="cell__title">
+                <span>Gopher</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../gravitar">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/gravitar.gif">
+            </div>
+            <div class="cell__title">
+                <span>Gravitar</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../hero">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/hero.gif">
+            </div>
+            <div class="cell__title">
+                <span>Hero</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../ice_hockey">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/ice_hockey.gif">
+            </div>
+            <div class="cell__title">
+                <span>Ice Hockey</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../jamesbond">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/jamesbond.gif">
+            </div>
+            <div class="cell__title">
+                <span>Jamesbond</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../journey_escape">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/journey_escape.gif">
+            </div>
+            <div class="cell__title">
+                <span>Journey Escape</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../kangaroo">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/kangaroo.gif">
+            </div>
+            <div class="cell__title">
+                <span>Kangaroo</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../krull">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/krull.gif">
+            </div>
+            <div class="cell__title">
+                <span>Krull</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../kung_fu_master">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/kung_fu_master.gif">
+            </div>
+            <div class="cell__title">
+                <span>Kung Fu Master</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../montezuma_revenge">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/montezuma_revenge.gif">
+            </div>
+            <div class="cell__title">
+                <span>Montezuma Revenge</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../ms_pacman">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/ms_pacman.gif">
+            </div>
+            <div class="cell__title">
+                <span>Ms Pacman</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../name_this_game">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/name_this_game.gif">
+            </div>
+            <div class="cell__title">
+                <span>Name This Game</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../phoenix">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/phoenix.gif">
+            </div>
+            <div class="cell__title">
+                <span>Phoenix</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../pitfall">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/pitfall.gif">
+            </div>
+            <div class="cell__title">
+                <span>Pitfall</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../pong">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/pong.gif">
+            </div>
+            <div class="cell__title">
+                <span>Pong</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../pooyan">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/pooyan.gif">
+            </div>
+            <div class="cell__title">
+                <span>Pooyan</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../private_eye">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/private_eye.gif">
+            </div>
+            <div class="cell__title">
+                <span>Private Eye</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../qbert">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/qbert.gif">
+            </div>
+            <div class="cell__title">
+                <span>Qbert</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../riverraid">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/riverraid.gif">
+            </div>
+            <div class="cell__title">
+                <span>Riverraid</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../road_runner">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/road_runner.gif">
+            </div>
+            <div class="cell__title">
+                <span>Road Runner</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../robotank">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/robotank.gif">
+            </div>
+            <div class="cell__title">
+                <span>Robotank</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../seaquest">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/seaquest.gif">
+            </div>
+            <div class="cell__title">
+                <span>Seaquest</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../skiing">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/skiing.gif">
+            </div>
+            <div class="cell__title">
+                <span>Skiing</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../solaris">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/solaris.gif">
+            </div>
+            <div class="cell__title">
+                <span>Solaris</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../space_invaders">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/space_invaders.gif">
+            </div>
+            <div class="cell__title">
+                <span>Space Invaders</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../star_gunner">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/star_gunner.gif">
+            </div>
+            <div class="cell__title">
+                <span>Star Gunner</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../tennis">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/tennis.gif">
+            </div>
+            <div class="cell__title">
+                <span>Tennis</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../time_pilot">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/time_pilot.gif">
+            </div>
+            <div class="cell__title">
+                <span>Time Pilot</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../tutankham">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/tutankham.gif">
+            </div>
+            <div class="cell__title">
+                <span>Tutankham</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../up_n_down">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/up_n_down.gif">
+            </div>
+            <div class="cell__title">
+                <span>Up N Down</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../venture">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/venture.gif">
+            </div>
+            <div class="cell__title">
+                <span>Venture</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../video_pinball">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/video_pinball.gif">
+            </div>
+            <div class="cell__title">
+                <span>Video Pinball</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../wizard_of_wor">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/wizard_of_wor.gif">
+            </div>
+            <div class="cell__title">
+                <span>Wizard Of Wor</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../yars_revenge">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/yars_revenge.gif">
+            </div>
+            <div class="cell__title">
+                <span>Yars Revenge</span>
+            </div>
+        </div>
+    </a>
+
+
+    <a href="../zaxxon">
+        <div class="env-grid__cell">
+            <div class="cell__image-container">
+                <img alt="environment video" src="../../_static/videos/environments/zaxxon.gif">
+            </div>
+            <div class="cell__title">
+                <span>Zaxxon</span>
+            </div>
+        </div>
+    </a>
+
+</div>

--- a/docs/environments/gym.md
+++ b/docs/environments/gym.md
@@ -1,0 +1,9 @@
+# Environments previously in Gym
+
+The following 62 games are the Atari environments that were registered in [OpenAI Gym](https://github.com/openai/gym) (through the `atari-py` package). They remain available with the same names through `ale-py` and [Gymnasium](https://gymnasium.farama.org), e.g., `Pong-v0` is now `ALE/Pong-v5`, see the [version history and naming schemes](https://ale.farama.org/environments/#version-history-and-naming-schemes) section for more details.
+
+This set contains all of the [Atari 57](atari_57) benchmark games except `Surround`, plus six additional games: `Adventure`, `AirRaid`, `Carnival`, `ElevatorAction`, `JourneyEscape` and `Pooyan`.
+
+```{raw} html
+:file: gym.html
+```

--- a/docs/environments/gym.md
+++ b/docs/environments/gym.md
@@ -1,4 +1,4 @@
-# Environments previously in Gym
+# Previously in OpenAI Gym
 
 The following 62 games are the Atari environments that were registered in [OpenAI Gym](https://github.com/openai/gym) (through the `atari-py` package). They remain available with the same names through `ale-py` and [Gymnasium](https://gymnasium.farama.org), e.g., `Pong-v0` is now `ALE/Pong-v5`, see the [version history and naming schemes](https://ale.farama.org/environments/#version-history-and-naming-schemes) section for more details.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,7 @@ env.close()
 getting-started
 env-spec
 environments
+environment-sets
 vector-environment
 multi-agent-environments
 wasm


### PR DESCRIPTION
## Description

Fixes #708

Adds sidebar-visible documentation pages listing the games in each commonly benchmarked subset of Atari environments, so multiple views exist simultaneously as suggested in the issue:

- **Atari 57** (`environments/atari_57`) — the 57 games of the DeepMind benchmark (DQN through Agent57), with references and a note that `Defender`/`Surround` were unavailable in `atari-py`, which is why some papers benchmark on only 55 of these games.
- **Previously in OpenAI Gym** (`environments/gym`) — the 62 games that were registered in OpenAI Gym, explaining the `Pong-v0` → `ALE/Pong-v5` naming migration and how the set relates to Atari 57 (all of it except `Surround`, plus `Adventure`, `AirRaid`, `Carnival`, `ElevatorAction`, `JourneyEscape` and `Pooyan`).
- **Complete list** — now included in a toctree (it previously wasn't in any), with cross-links to the set pages.

The Environments page gets a visible "Environment sets" section linking the three views, and the three pages live under a separate "Environment Sets" sidebar dropdown directly below Environments (per review, keeping the Environments dropdown to just the individual game pages).

The new pages follow the existing `complete_list` pattern: a checked-in `env-grid` HTML file embedded in a markdown page via `{raw} html`, using the same relative-link style (correct for the `dirhtml` builder used in CI). The grids were generated programmatically from the display names in `complete_list.html`, with assertions validating both set definitions and the relationship between them. Additional sets (e.g., the DQN Nature 49) can be added the same way if desired.

Sphinx build succeeds with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
