### PR TITLE
Fix cloneState/restoreState losing the TIA's frame state

### DIFF
--- a/src/ale/emucore/TIA.cxx
+++ b/src/ale/emucore/TIA.cxx
@@ -39,6 +39,77 @@ static std::once_flag tia_init_once;
 namespace ale {
 namespace stella {
 
+// ALE: the frame buffers are large (160 x 300 each) but almost entirely flat, so a
+// (value, run-length) encoding takes the pair from 96000 bytes down to a few KB. That is
+// what makes it affordable to put the screen into the saved state at all - see the
+// matching comment in TIA::save().
+namespace {
+
+const uint32_t FRAME_BUFFER_SIZE = 160 * 300;
+
+std::string rleEncode(const uint8_t* buffer, uint32_t length)
+{
+  std::string out;
+  out.reserve(4096);
+
+  uint32_t i = 0;
+  while(i < length)
+  {
+    const uint8_t value = buffer[i];
+    const uint32_t limit = ((length - i) < 255) ? (length - i) : 255;
+
+    // Most of a frame buffer is long flat runs, so compare eight bytes at a time against
+    // the repeated value before finishing byte-wise. Encoding is on the cloneState() path,
+    // which some callers run in a hot loop.
+    uint64_t repeated;
+    std::memset(&repeated, value, sizeof(repeated));
+
+    uint32_t run = 1;
+    while((run + 8) <= limit && std::memcmp(buffer + i + run, &repeated, 8) == 0)
+      run += 8;
+    while(run < limit && buffer[i + run] == value)
+      ++run;
+
+    out.push_back((char) value);
+    out.push_back((char) run);
+    i += run;
+  }
+
+  return out;
+}
+
+// Returns false on a malformed or truncated encoding rather than writing past the buffer:
+// a state blob can come from anywhere (ALEState::deserialize).
+bool rleDecode(const std::string& in, uint8_t* buffer, uint32_t length)
+{
+  uint32_t written = 0;
+
+  for(std::string::size_type i = 0; (i + 1) < in.size(); i += 2)
+  {
+    uint32_t run = (uint8_t) in[i + 1];
+    if(run == 0 || (written + run) > length)
+      return false;
+
+    std::memset(buffer + written, (uint8_t) in[i], run);
+    written += run;
+  }
+
+  return written == length;
+}
+
+// ALE: restore a table pointer that was saved as an element offset, refusing an
+// out-of-range offset rather than handing back a wild pointer.
+template <typename T>
+const T* offsetInto(const T* base, int offset, int count)
+{
+  if(offset < 0 || offset >= count)
+    return base;
+  return base + offset;
+}
+
+}  // namespace
+
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TIA::TIA(const Console& console, Settings& settings)
     : myConsole(console),
@@ -371,13 +442,18 @@ bool TIA::save(Serializer& out)
     out.putInt(myCurrentGRP0);
     out.putInt(myCurrentGRP1);
 
-// pointers
-//  myCurrentBLMask = ourBallMaskTable[0][0];
-//  myCurrentM0Mask = ourMissleMaskTable[0][0][0];
-//  myCurrentM1Mask = ourMissleMaskTable[0][0][0];
-//  myCurrentP0Mask = ourPlayerMaskTable[0][0][0];
-//  myCurrentP1Mask = ourPlayerMaskTable[0][0][0];
-//  myCurrentPFMask = ourPlayfieldTable[0];
+    // ALE: these six point into the static mask tables and were previously left out of
+    // the state (the commented-out lines above). They are only recomputed when the
+    // register that derives them is next poked, so between pokes they are live state: a
+    // restore left them pointing wherever the receiving instance happened to be, which
+    // renders the first frame wrong (yars_revenge). Saved as element offsets, since the
+    // tables are static and the pointers themselves are not portable.
+    out.putInt((int)(myCurrentBLMask - &ourBallMaskTable[0][0][0]));
+    out.putInt((int)(myCurrentM0Mask - &ourMissleMaskTable[0][0][0][0]));
+    out.putInt((int)(myCurrentM1Mask - &ourMissleMaskTable[0][0][0][0]));
+    out.putInt((int)(myCurrentP0Mask - &ourPlayerMaskTable[0][0][0][0]));
+    out.putInt((int)(myCurrentP1Mask - &ourPlayerMaskTable[0][0][0][0]));
+    out.putInt((int)(myCurrentPFMask - &ourPlayfieldTable[0][0]));
 
     out.putInt(myLastHMOVEClock);
     out.putBool(myHMOVEBlankEnabled);
@@ -391,6 +467,27 @@ bool TIA::save(Serializer& out)
     // rebases the cycle counters, so a restore into an emulator whose flag disagrees runs
     // a different number of cycles in its next frame.
     out.putBool(myPartialFrameFlag);
+
+    // ALE: myFramePointer is the write cursor into myCurrentFrameBuffer, and it is only
+    // rebased by startFrame(), which update() skips while myPartialFrameFlag is set. A
+    // mid-frame state restored into an emulator whose cursor sits elsewhere therefore
+    // renders the rest of the frame at the wrong offset, and once the restored clock
+    // counters imply more scanline than the cursor has buffer left, updateFrameScanline()
+    // writes past the end of it. Stored as an offset because the two frame buffers are
+    // per-instance heap allocations and startFrame() swaps them every frame.
+    out.putInt((int)(myFramePointer - myCurrentFrameBuffer));
+
+    // ALE: set by update() when it greys out an unfinished frame, cleared by startFrame();
+    // without it a restored partial frame can be greyed twice or not at all.
+    out.putBool(myFrameGreyed);
+
+    // ALE: the frame buffers themselves. startFrame() swaps them, so a game that repaints
+    // only part of the screen inherits pixels from two frames back; a restore that does not
+    // carry them renders visibly wrong frames until every scanline has been repainted
+    // (measured across the 104 loadable ROMs: 4 games affected, up to 94% of the first
+    // frame's pixels, clearing within two frames). RLE keeps the cost to a few KB.
+    out.putString(rleEncode(myCurrentFrameBuffer, FRAME_BUFFER_SIZE));
+    out.putString(rleEncode(myPreviousFrameBuffer, FRAME_BUFFER_SIZE));
 
     // Save the sound sample stuff ...
     mySound->save(out);
@@ -473,13 +570,19 @@ bool TIA::load(Deserializer& in)
     myCurrentGRP0 = (uint8_t) in.getInt();
     myCurrentGRP1 = (uint8_t) in.getInt();
 
-// pointers
-//  myCurrentBLMask = ourBallMaskTable[0][0];
-//  myCurrentM0Mask = ourMissleMaskTable[0][0][0];
-//  myCurrentM1Mask = ourMissleMaskTable[0][0][0];
-//  myCurrentP0Mask = ourPlayerMaskTable[0][0][0];
-//  myCurrentP1Mask = ourPlayerMaskTable[0][0][0];
-//  myCurrentPFMask = ourPlayfieldTable[0];
+    // ALE: see the matching comment in save().
+    myCurrentBLMask = offsetInto(&ourBallMaskTable[0][0][0], (int) in.getInt(),
+                                 4 * 4 * 320);
+    myCurrentM0Mask = offsetInto(&ourMissleMaskTable[0][0][0][0], (int) in.getInt(),
+                                 4 * 8 * 4 * 320);
+    myCurrentM1Mask = offsetInto(&ourMissleMaskTable[0][0][0][0], (int) in.getInt(),
+                                 4 * 8 * 4 * 320);
+    myCurrentP0Mask = offsetInto(&ourPlayerMaskTable[0][0][0][0], (int) in.getInt(),
+                                 4 * 2 * 8 * 320);
+    myCurrentP1Mask = offsetInto(&ourPlayerMaskTable[0][0][0][0], (int) in.getInt(),
+                                 4 * 2 * 8 * 320);
+    myCurrentPFMask = offsetInto(&ourPlayfieldTable[0][0], (int) in.getInt(),
+                                 2 * 160);
 
     myLastHMOVEClock = (int) in.getInt();
     myHMOVEBlankEnabled = in.getBool();
@@ -490,6 +593,23 @@ bool TIA::load(Deserializer& in)
     myDumpDisabledCycle = (int) in.getInt();
 
     myPartialFrameFlag = in.getBool();
+
+    // ALE: see the matching comment in save(). Clamped because an out-of-range offset here
+    // is a wild pointer, and a state blob can come from anywhere (ALEState::deserialize).
+    int framePointerOffset = (int) in.getInt();
+    if(framePointerOffset < 0)
+      framePointerOffset = 0;
+    else if(framePointerOffset > (int)(160 * 300))
+      framePointerOffset = 160 * 300;
+    myFramePointer = myCurrentFrameBuffer + framePointerOffset;
+
+    myFrameGreyed = in.getBool();
+
+    // ALE: see the matching comment in save(). Restored by role, not by address - the two
+    // buffers are per-instance allocations that startFrame() swaps.
+    if(!rleDecode(in.getString(), myCurrentFrameBuffer, FRAME_BUFFER_SIZE) ||
+       !rleDecode(in.getString(), myPreviousFrameBuffer, FRAME_BUFFER_SIZE))
+      return false;
 
     // Load the sound sample stuff ...
     mySound->load(in);

--- a/tests/python/test_python_interface.py
+++ b/tests/python/test_python_interface.py
@@ -391,6 +391,65 @@ def test_clone_restore_system_state(ale, tetris_rom_path):
         assert first == second
 
 
+def test_restore_reproduces_screen(ale, tetris_rom_path):
+    """A restored state must reproduce the screen, not just RAM.
+
+    The state cloned immediately after `reset_game()` is the one a snapshot-based reset
+    reuses, and it is the one that used to break: TIA state that reaches nothing but the
+    frame buffer (the frame cursor, the object mask pointers, the buffers themselves) was
+    left out of the serialized state, so the first frames after a restore rendered wrong.
+    """
+    ale.setInt("random_seed", 0)
+    ale.setFloat("repeat_action_probability", 0.0)
+    ale.loadROM(tetris_rom_path)
+    ale.reset_game()
+
+    actions = ale.getMinimalActionSet()
+    stream = [actions[i % len(actions)] for i in range(12)]
+    state = ale.cloneState()
+
+    reference = []
+    for action in stream:
+        ale.act(action)
+        reference.append((ale.getScreen().copy(), ale.getRAM().copy()))
+
+    ale.restoreState(state)
+    for action, (screen, ram) in zip(stream, reference):
+        ale.act(action)
+        np.testing.assert_array_equal(ale.getScreen(), screen)
+        np.testing.assert_array_equal(ale.getRAM(), ram)
+
+
+def test_repeated_restore_of_one_state(ale, tetris_rom_path):
+    """Restoring the *same* state many times must stay exact, and must not corrupt memory.
+
+    This is the vectorised-autoreset access pattern. A single restore can leave per-frame
+    TIA state inconsistent with the restored clock counters without visible damage; it took
+    repeated restores for the frame cursor to walk off the end of the frame buffer, so a
+    one-shot round-trip check passed while the same state corrupted the heap in a loop.
+    """
+    ale.setInt("random_seed", 0)
+    ale.setFloat("repeat_action_probability", 0.0)
+    ale.loadROM(tetris_rom_path)
+    ale.reset_game()
+
+    actions = ale.getMinimalActionSet()
+    stream = [actions[i % len(actions)] for i in range(4)]
+    state = ale.cloneState()
+
+    reference = []
+    for action in stream:
+        ale.act(action)
+        reference.append((ale.getScreen().copy(), ale.getRAM().copy()))
+
+    for _ in range(500):
+        ale.restoreState(state)
+        for action, (screen, ram) in zip(stream, reference):
+            ale.act(action)
+            np.testing.assert_array_equal(ale.getScreen(), screen)
+            np.testing.assert_array_equal(ale.getRAM(), ram)
+
+
 def test_state_pickle(tetris):
     for _ in range(10):
         tetris.act(0)


### PR DESCRIPTION
Follow-up to #732, which added `myPartialFrameFlag` to the serialised state. `TIA::save`/`load` covers the registers and timing counters but not the state that only ever reaches the frame buffer, so a restored state renders the wrong frames — and in one case writes outside the buffer. Four things were missing: `myFramePointer` (the write cursor into the current frame buffer), `myFrameGreyed`, the six object-mask pointers (which were explicitly commented out of the state), and the two frame buffers themselves. `startFrame()` swaps those buffers and a game may repaint only part of the screen, so a restore that does not carry them renders visibly wrong frames until every scanline has been repainted — up to 94% of the first frame's pixels on amidar, koolaid, qbert and tetris, clearing within two frames. `myFramePointer` is the more serious one: it is only rebased by `startFrame()`, which `update()` skips while `myPartialFrameFlag` is set, so restoring a mid-frame state leaves the cursor inconsistent with the restored counters. Restore the same state repeatedly — what a vectorised autoreset does — and `updateFrameScanline()` eventually memsets past the end of the buffer; qbert aborts with `double free or corruption` after ~2000 restores, reachable from the plain single-environment Python API with no vector env involved.

Pointers are serialised as offsets, since the frame buffers are per-instance allocations and the mask pointers index static tables, and every offset is range-checked on load — `ALEState::deserialize` will accept a blob from anywhere. The frame buffers are run-length encoded, so 96,000 bytes of buffer costs a few KB. Cost: `cloneState` 21–23 µs → 37–51 µs, `restoreState` 24–25 µs → 33–44 µs, serialised state 7.7 KB → 9.2–17 KB. Verified with a clone/restore sweep over all 104 loadable ROMs that compares the screen as well as RAM/reward/lives/terminal — 104,000 snapshot points, for both `cloneState` and `cloneSystemState`; before this change, restoring one snapshot repeatedly failed on 4 ROMs and crashed on qbert. Two pytest cases cover both shapes: one restore, and 500 restores of the same state.

**One question for maintainers:** this changes the state blob layout, so previously serialised states will not load. Would you like a state-serialisation version bump to go with it?
