### PR TITLE
Fix the XLA GPU handlers' cudaMemcpyAsync source lifetimes

### DIFF
--- a/src/ale/python/ale_vector_xla_interface.cpp
+++ b/src/ale/python/ale_vector_xla_interface.cpp
@@ -153,11 +153,14 @@ ffi::Error XLAResetGPUImpl(
     if (new_handle_buffer->element_count() != handle_buffer.element_count()) {
         return ffi::Error::Internal("Incorrect new handle buffer size in reset (GPU)");
     }
-    err = cudaMemcpyAsync(new_handle_buffer->typed_data(), host_handle.data(),
+    // Device-to-device: the handle is already on the device, and copying it
+    // straight across avoids issuing a transfer out of host_handle, which dies
+    // with this call.
+    err = cudaMemcpyAsync(new_handle_buffer->typed_data(), handle_buffer.typed_data(),
                           handle_buffer.element_count(),
-                          cudaMemcpyHostToDevice, stream);
+                          cudaMemcpyDeviceToDevice, stream);
     if (err != cudaSuccess) {
-        return ffi::Error::Internal(std::string("CUDA memcpy failed (new handle H2D): ") + cudaGetErrorString(err));
+        return ffi::Error::Internal(std::string("CUDA memcpy failed (new handle D2D): ") + cudaGetErrorString(err));
     }
 
     try {
@@ -240,6 +243,14 @@ ffi::Error XLAResetGPUImpl(
         err = cudaGetLastError();
         if (err != cudaSuccess) {
             return ffi::Error::Internal(std::string("CUDA error after operations: ") + cudaGetErrorString(err));
+        }
+
+        // The copies above read out of the BatchResult, which is destroyed when
+        // this scope ends, so they must complete before we return. Resets are
+        // rare enough that the wait does not matter.
+        err = cudaStreamSynchronize(stream);
+        if (err != cudaSuccess) {
+            return ffi::Error::Internal(std::string("CUDA stream sync failed (reset results): ") + cudaGetErrorString(err));
         }
 
         return ffi::Error::Success();
@@ -442,11 +453,14 @@ ffi::Error XLAStepGPUImpl(
     if (new_handle_buffer->element_count() != handle_buffer.element_count()) {
         return ffi::Error::Internal("New handle buffer is the wrong size (GPU)");
     }
-    err = cudaMemcpyAsync(new_handle_buffer->typed_data(), host_handle.data(),
+    // Device-to-device: the handle is already on the device, and copying it
+    // straight across avoids issuing a transfer out of host_handle, which dies
+    // with this call.
+    err = cudaMemcpyAsync(new_handle_buffer->typed_data(), handle_buffer.typed_data(),
                           handle_buffer.element_count(),
-                          cudaMemcpyHostToDevice, stream);
+                          cudaMemcpyDeviceToDevice, stream);
     if (err != cudaSuccess) {
-        return ffi::Error::Internal(std::string("CUDA memcpy failed (new handle H2D): ") + cudaGetErrorString(err));
+        return ffi::Error::Internal(std::string("CUDA memcpy failed (new handle D2D): ") + cudaGetErrorString(err));
     }
 
     try {
@@ -577,6 +591,16 @@ ffi::Error XLAStepGPUImpl(
         err = cudaGetLastError();
         if (err != cudaSuccess) {
             return ffi::Error::Internal(std::string("CUDA error after operations: ") + cudaGetErrorString(err));
+        }
+
+        // Every copy above reads from memory that dies with this call - the
+        // BatchResult and the two host_* vectors - so the transfers have to
+        // finish before we return. cudaMemcpyAsync out of pageable memory
+        // happens to stage synchronously today, which is the only reason this
+        // was ever safe without the wait.
+        err = cudaStreamSynchronize(stream);
+        if (err != cudaSuccess) {
+            return ffi::Error::Internal(std::string("CUDA stream sync failed (step results): ") + cudaGetErrorString(err));
         }
 
         return ffi::Error::Success();


### PR DESCRIPTION
Both XLA GPU FFI handlers issue `cudaMemcpyAsync` calls whose *sources* die with the call and are never synchronised: the local `host_handle` behind the new-handle copy, the local `BatchResult` behind all six result copies, and `host_terminations`/`host_truncations` in the step handler. Nothing waits for those transfers before the handler returns and the memory goes away. This is safe today only because `cudaMemcpyAsync` out of pageable memory happens to be staged synchronously through the driver's own bounce buffer — an implementation detail rather than a guarantee, and one that stops holding as soon as the source is page-locked.

Three fixes, no behaviour change: `new_handle` is now copied device-to-device, since the handle is already on the device and the copy needs no host source at all; and the reset handler and the step handler each `cudaStreamSynchronize` before returning, because every source they read is transient. `tests/python/test_atari_vector_xla.py` passes on a CUDA build (jax 0.11.0, CUDA 12).
